### PR TITLE
Refactor filter logic, and allow a list of filters in config

### DIFF
--- a/src/filters/namespace.rs
+++ b/src/filters/namespace.rs
@@ -5,7 +5,7 @@ use crate::scanners::interface::ResourceThreadSafe;
 
 use super::filter::{Filter, FilterDefinition, FilterRegex, FilterType};
 
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Default, Deserialize, Debug)]
 #[serde(try_from = "String")]
 pub struct NamespaceInclude {
     namespace: FilterRegex,
@@ -15,22 +15,20 @@ pub struct NamespaceInclude {
 /// list. Returns true if the object's namespace is in the allowed namespaces,
 /// or the namespace list is empty or the resource is cluster-scoped.
 impl<R: ResourceThreadSafe> Filter<R> for NamespaceInclude {
-    fn filter_object(&self, obj: &R) -> bool {
-        let accepted = obj.namespace().unwrap_or_default().is_empty()
-            || self.namespace.matches(&obj.namespace().unwrap_or_default());
-
-        if !accepted {
-            log::debug!(
-                "NamespaceInclude filter excluded {}/{} as it is not present in the namespace list {}",
-                obj.name_any(),
-                obj.namespace().unwrap(), self.namespace);
+    fn filter_object(&self, obj: &R, _: &GroupVersionKind) -> Option<bool> {
+        let empty = obj.namespace().unwrap_or_default().is_empty();
+        let included = self.namespace.matches(&obj.namespace().unwrap_or_default());
+        match (empty, included) {
+            (true, _) => None,
+            (false, true) => Some(true),
+            (false, false) => {
+                log::debug!(
+                    "NamespaceExclude filter excluded {}/{} as it is not present in the namespace list {}",
+                    obj.name_any(),
+                    obj.meta().clone().namespace.unwrap(), self.namespace);
+                Some(false)
+            }
         }
-
-        accepted
-    }
-
-    fn filter_api(&self, _: &GroupVersionKind) -> bool {
-        true
     }
 }
 
@@ -46,13 +44,13 @@ impl TryFrom<String> for NamespaceInclude {
     }
 }
 
-impl From<NamespaceInclude> for FilterType {
-    fn from(val: NamespaceInclude) -> Self {
+impl From<Vec<NamespaceInclude>> for FilterType {
+    fn from(val: Vec<NamespaceInclude>) -> Self {
         Self::NamespaceInclude(val)
     }
 }
 
-#[derive(Clone, Default, Deserialize)]
+#[derive(Clone, Default, Deserialize, Debug)]
 #[serde(try_from = "String")]
 pub struct NamespaceExclude {
     namespace: FilterRegex,
@@ -70,29 +68,27 @@ impl TryFrom<String> for NamespaceExclude {
     }
 }
 
-impl From<NamespaceExclude> for FilterType {
-    fn from(val: NamespaceExclude) -> Self {
+impl From<Vec<NamespaceExclude>> for FilterType {
+    fn from(val: Vec<NamespaceExclude>) -> Self {
         Self::NamespaceExclude(val)
     }
 }
 
 impl<R: ResourceThreadSafe> Filter<R> for NamespaceExclude {
-    fn filter_object(&self, obj: &R) -> bool {
-        let accepted = obj.namespace().unwrap_or_default().is_empty()
-            || !self.namespace.matches(&obj.namespace().unwrap_or_default());
-
-        if !accepted {
-            log::debug!(
-                "NamespaceExclude filter excluded {}/{} as it is not present in the namespace list {}",
-                obj.name_any(),
-                obj.meta().clone().namespace.unwrap(), self.namespace);
+    fn filter_object(&self, obj: &R, _: &GroupVersionKind) -> Option<bool> {
+        let empty = obj.namespace().unwrap_or_default().is_empty();
+        let excluded = !self.namespace.matches(&obj.namespace().unwrap_or_default());
+        match (empty, excluded) {
+            (true, _) => None,
+            (false, true) => Some(true),
+            (false, false) => {
+                log::debug!(
+                    "NamespaceExclude filter excluded {}/{} as it is not present in the namespace list {}",
+                    obj.name_any(),
+                    obj.meta().clone().namespace.unwrap(), self.namespace);
+                Some(false)
+            }
         }
-
-        accepted
-    }
-
-    fn filter_api(&self, _: &GroupVersionKind) -> bool {
-        true
     }
 }
 
@@ -100,34 +96,83 @@ impl<R: ResourceThreadSafe> Filter<R> for NamespaceExclude {
 mod tests {
 
     use k8s_openapi::api::core::v1::Pod;
-    use kube_core::{ApiResource, DynamicObject};
+    use kube_core::{ApiResource, DynamicObject, TypeMeta};
 
     use super::*;
 
+    static POD: &str = r"---
+    apiVersion: v1
+    kind: Pod";
+
     #[test]
     fn test_include_namespace_filter() {
+        let pod_tm: TypeMeta = serde_yaml::from_str(POD).unwrap();
+
         let filter = NamespaceInclude::try_from("default".to_string()).unwrap();
 
         let obj = DynamicObject::new("test", &ApiResource::erase::<Pod>(&())).within("default");
-        assert!(filter.filter_object(&obj));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            Some(true)
+        );
 
         let filter = NamespaceInclude::try_from("default".to_string()).unwrap();
 
         let obj = DynamicObject::new("other", &ApiResource::erase::<Pod>(&())).within("other");
-        assert!(!filter.filter_object(&obj));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            Some(false)
+        );
+
+        let obj = DynamicObject::new("other", &ApiResource::erase::<Pod>(&()));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            None
+        );
     }
 
     #[test]
     fn test_exclude_namespace() {
+        let pod_tm: TypeMeta = serde_yaml::from_str(POD).unwrap();
         let filter = NamespaceExclude::try_from("default".to_string()).unwrap();
 
         let obj = DynamicObject::new("test", &ApiResource::erase::<Pod>(&())).within("default");
-        assert!(!filter.filter_object(&obj));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            Some(false)
+        );
 
         let filter = NamespaceExclude::try_from("default".to_string()).unwrap();
 
         let obj = DynamicObject::new("test", &ApiResource::erase::<Pod>(&())).within("other");
-        assert!(filter.filter_object(&obj));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            Some(true)
+        );
+
+        let obj = DynamicObject::new("other", &ApiResource::erase::<Pod>(&()));
+        assert_eq!(
+            filter.filter_object(
+                &obj,
+                &GroupVersionKind::try_from(&pod_tm).expect("parse GVK")
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,15 @@ async fn main() -> anyhow::Result<()> {
     cli.init();
 
     match cli.command {
-        cli::Commands::CollectFromConfig { config } | cli::Commands::Collect { config } => {
+        cli::Commands::Collect { config } => {
             Into::<GatherCommands>::into(config)
+                .load()
+                .await?
+                .collect()
+                .await?
+        }
+        cli::Commands::CollectFromConfig { config, overrides } => {
+            Into::<GatherCommands>::into(config.merge(overrides))
                 .load()
                 .await?
                 .collect()

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -86,7 +86,7 @@ mod test {
     use tokio_retry::{strategy::FixedInterval, Retry};
 
     use crate::{
-        filters::{filter::List, namespace::NamespaceInclude},
+        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
         gather::{
             config::Config,
             writer::{Archive, Encoding, Writer},
@@ -148,7 +148,7 @@ mod test {
             collectable: Objects::new(
                 Config::new(
                     test_env.client().await,
-                    List(vec![filter.into()]),
+                    FilterGroup(vec![FilterList(vec![vec![filter].into()])]),
                     Writer::new(&Archive::new(file_path), &Encoding::Path)
                         .expect("failed to create builder"),
                     Default::default(),

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -155,7 +155,7 @@ mod test {
     use tokio_retry::{strategy::FixedInterval, Retry};
 
     use crate::{
-        filters::{filter::List, namespace::NamespaceInclude},
+        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
         gather::{
             config::Config,
             writer::{Archive, Encoding, Writer},
@@ -210,7 +210,7 @@ mod test {
             collectable: Objects::new_typed(
                 Config::new(
                     test_env.client().await,
-                    List(vec![filter.into()]),
+                    FilterGroup(vec![FilterList(vec![vec![filter].into()])]),
                     Writer::new(&Archive::new(file_path), &Encoding::Path)
                         .expect("failed to create builder"),
                     Default::default(),

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -112,7 +112,7 @@ mod test {
     use tokio_retry::Retry;
 
     use crate::{
-        filters::{filter::List, namespace::NamespaceInclude},
+        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
         gather::{
             config::Config,
             representation::ArchivePath,
@@ -169,7 +169,7 @@ mod test {
         let repr = Objects::new(
             Config::new(
                 test_env.client().await,
-                List(vec![filter.into()]),
+                FilterGroup(vec![FilterList(vec![vec![filter].into()])]),
                 Writer::new(&Archive::new("crust-gather".into()), &Encoding::Path)
                     .expect("failed to create builder"),
                 Default::default(),
@@ -199,7 +199,7 @@ mod test {
         let collectable = Objects::new(
             Config::new(
                 test_env.client().await,
-                List(vec![]),
+                FilterGroup(vec![FilterList(vec![])]),
                 Writer::new(&Archive::new("crust-gather".into()), &Encoding::Path)
                     .expect("failed to create builder"),
                 Default::default(),
@@ -225,7 +225,7 @@ mod test {
         let collectable = Objects::new(
             Config::new(
                 test_env.client().await,
-                List(vec![]),
+                FilterGroup(vec![FilterList(vec![])]),
                 Writer::new(&Archive::new("crust-gather".into()), &Encoding::Path)
                     .expect("failed to create builder"),
                 Default::default(),


### PR DESCRIPTION
Provide ability to specify granular filters via config file in a list:
```yaml

filters:
- include_namespace:
  - kube-system
  - default
  - kube-system
  include_kind:
  - Pod
  - Node
- include_namespace:
  - kube-system
  include_kind:
  - Deployment
- include_namespace:
  - cert-manager
  include_kind:
  - ReplicaSet
- include_namespace:
  - default
  include_kind:
  - CoreProvider
settings:
  insecure_skip_tls_verify: true
```