### PR TITLE
Add --secrets-file CLI option

### DIFF
--- a/src/gather/writer.rs
+++ b/src/gather/writer.rs
@@ -342,7 +342,7 @@ mod tests {
 
             let mut data = String::new();
             file.read_to_string(&mut data).unwrap();
-            assert_eq!(data, "content with ***");
+            assert_eq!(data, "content with xxx");
         }
 
         check_zip_contents(File::open(archive).unwrap());
@@ -366,7 +366,7 @@ mod tests {
         assert!(archive.exists());
         assert!(archive.join("test.txt").exists());
         let data = fs::read_to_string(archive.join("test.txt")).unwrap();
-        assert_eq!(data, "content with ***");
+        assert_eq!(data, "content with xxx");
     }
 
     #[test]


### PR DESCRIPTION
By specifying `kubectl crust-gather collect --secrets-file secrets.txt`, all secret strings from file will be excluded from collected resources.

Example secrets file:
```bash
cat secrets.txt 
10.244.0.0
172.18.0.3
my-password
```