### PR TITLE
Allow to read config from config map in the cluster

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,11 @@ async fn main() -> anyhow::Result<()> {
                 .collect()
                 .await?
         }
-        cli::Commands::CollectFromConfig { config, overrides } => {
-            Into::<GatherCommands>::into(config.merge(overrides))
+        cli::Commands::CollectFromConfig { source, overrides } => {
+            source
+                .gather(overrides.client().await?)
+                .await?
+                .merge(overrides)
                 .load()
                 .await?
                 .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,33 +8,14 @@ mod tests;
 
 use clap::{self, Parser};
 
-use crate::cli::{Cli, GatherCommands};
+use crate::cli::Cli;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     cli.init();
 
-    match cli.command {
-        cli::Commands::Collect { config } => {
-            Into::<GatherCommands>::into(config)
-                .load()
-                .await?
-                .collect()
-                .await?
-        }
-        cli::Commands::CollectFromConfig { source, overrides } => {
-            source
-                .gather(overrides.client().await?)
-                .await?
-                .merge(overrides)
-                .load()
-                .await?
-                .collect()
-                .await?
-        }
-        cli::Commands::Serve { serve } => serve.get_api()?.serve().await?,
-    };
+    cli.command.run().await?;
 
     log::info!("Done");
     Ok(())

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -86,7 +86,10 @@ mod test {
     use tokio_retry::{strategy::FixedInterval, Retry};
 
     use crate::{
-        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
+        filters::{
+            filter::{FilterGroup, FilterList},
+            namespace::NamespaceInclude,
+        },
         gather::{
             config::Config,
             writer::{Archive, Encoding, Writer},

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -155,7 +155,10 @@ mod test {
     use tokio_retry::{strategy::FixedInterval, Retry};
 
     use crate::{
-        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
+        filters::{
+            filter::{FilterGroup, FilterList},
+            namespace::NamespaceInclude,
+        },
         gather::{
             config::Config,
             writer::{Archive, Encoding, Writer},

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -112,7 +112,10 @@ mod test {
     use tokio_retry::Retry;
 
     use crate::{
-        filters::{filter::{FilterGroup, FilterList}, namespace::NamespaceInclude},
+        filters::{
+            filter::{FilterGroup, FilterList},
+            namespace::NamespaceInclude,
+        },
         gather::{
             config::Config,
             representation::ArchivePath,


### PR DESCRIPTION
Provide an option for `collect-from-config` subcommand to specify a config map by name to read a config with filters. These will be applied to the cluster gathering.

Example from help:
```
Options:
      --config-map <CONFIG_MAP>
          Parse the gather configuration from an in-cluster config map specified by a name.
          
          Example content:
          
          apiVersion: v1
          kind: ConfigMap
          metadata:
            name: crust-gather-config
          data: |
            filters:
            - include_namespace:
              - default
              include_kind:
              - Pod
            settings:
              secret:
              - FOO
              - BAR
          
          Example:
              --config-map=crust-gather-config
```