### PR TITLE
Allow using kubeconfig from secret for resource collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ actix-web = "4.4.1"
 glob = "0.3.1"
 http = "0.2.11"
 serde_json_path = "0.6.4"
+base64 = "0.22.0"
 
 [features]
 archive = ["dep:tar", "dep:flate2", "dep:zip"]

--- a/src/gather/representation.rs
+++ b/src/gather/representation.rs
@@ -9,9 +9,10 @@ use serde::Deserialize;
 
 use crate::scanners::interface::ResourceThreadSafe;
 
+#[derive(Default, Clone, Deserialize, Debug)]
 pub struct NamespaceName {
-    name: Option<String>,
-    namespace: Option<String>,
+    pub name: Option<String>,
+    pub namespace: Option<String>,
 }
 
 impl NamespaceName {
@@ -23,6 +24,17 @@ impl NamespaceName {
         Self {
             name: obj.meta().name.clone(),
             namespace: obj.meta().namespace.clone(),
+        }
+    }
+}
+
+impl From<String> for NamespaceName {
+    fn from(value: String) -> Self {
+        match value.split_once('/') {
+            Some(("", name)) => NamespaceName::new(Some(name.into()), None),
+            Some((ns, "")) => NamespaceName::new(None, Some(ns.into())),
+            Some((ns, name)) => NamespaceName::new(Some(name.into()), Some(ns.into())),
+            None => NamespaceName::new(Some(value), None),
         }
     }
 }


### PR DESCRIPTION
```
Usage:
      --kubeconfig-secret-label <key=value>
          Collect kubeconfig from a first secret matching the label. Allows you to specify a label selector, and use the current cluster as a proxy to the one, where a snapshot will be collected. If not provided, --kubeconfig flag takes precedence.
          
          Example: --kubeconfig-secret-label=cluster.x-k8s.io/cluster-name=docker

      --kubeconfig-secret-name <NAMESPACE/NAME>
          Collect kubeconfig from a secret. Secret can be specified by namespace/name or just by name. If not provided, --kubeconfig flag takes precedence.
          
          Example: --kubeconfig-secret-name=default/cluster-kubeconfig
```

Allows to use cluster as a proxy for another cluster to collect resources from. Kubeconfig will be fetched from secret matching label. Could be used in conjunction with `--config-map` or `--config` to allow powerful collection filters and credentials for connection to be stored in the cluster.

Example:
```
kubectl crust-gather collect-from-config  --kubeconfig-secret-label=cluster.x-k8s.io/cluster-name=docker --config-map=docker-cluster-config
```