### PR TITLE
Use provided server path to serve multiple cluster snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "tokio-retry",
  "tokio-util",
  "trait-set",
+ "walkdir",
  "xid",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ glob = "0.3.1"
 http = "1.1.0"
 serde_json_path = "0.6.4"
 base64 = "0.22.0"
+walkdir = "2.5.0"
 
 [features]
 archive = ["dep:tar", "dep:flate2", "dep:zip"]

--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -17,7 +17,19 @@ use super::{
 };
 
 #[derive(Deserialize, Clone)]
+pub struct Destination {
+    server: String,
+}
+
+impl Destination {
+    pub fn get_server(&self) -> &str {
+        &self.server
+    }
+}
+
+#[derive(Deserialize, Clone)]
 pub struct Get {
+    server: String,
     namespace: Option<String>,
     name: String,
     group: Option<String>,
@@ -26,6 +38,10 @@ pub struct Get {
 }
 
 impl Get {
+    pub fn get_server(&self) -> &str {
+        &self.server
+    }
+
     pub fn get_path(&self) -> ArchivePath {
         ArchivePath::new_path(
             NamespaceName::new(Some(self.name.clone()), self.namespace.clone()),
@@ -65,6 +81,7 @@ pub struct Log {
 
 #[derive(Deserialize, Clone)]
 pub struct List {
+    pub server: String,
     namespace: Option<String>,
     group: Option<String>,
     version: String,
@@ -72,6 +89,10 @@ pub struct List {
 }
 
 impl List {
+    pub fn get_server(&self) -> &str {
+        &self.server
+    }
+
     pub fn get_path(&self) -> ArchivePath {
         ArchivePath::new_path(
             NamespaceName::new(None, self.namespace.clone()),
@@ -197,15 +218,8 @@ impl FromIterator<TableEntry> for Table {
 pub struct Reader(Archive);
 
 impl Reader {
-    pub fn new(archive: &Archive) -> anyhow::Result<Self> {
-        if !archive.path().exists() {
-            bail!(
-                "Archive {} does not exists",
-                archive.path().to_str().unwrap()
-            );
-        }
-
-        Ok(Self(archive.clone()))
+    pub fn new(archive: &Archive) -> Self {
+        Self(archive.clone())
     }
 
     pub fn load_table(&self, list: List) -> anyhow::Result<serde_json::Value> {

--- a/src/scanners/versions.rs
+++ b/src/scanners/versions.rs
@@ -57,7 +57,7 @@ impl Collect<Pod> for Versions {
             .list()
             .await?
             .iter()
-            .filter_map(|pod| pod.spec.clone().and_then(|s| Some((pod.meta(), s))))
+            .filter_map(|pod| pod.spec.clone().map(|s| (pod.meta(), s)))
             .flat_map(|(meta, spec)| {
                 spec.containers.into_iter().map(|container| Version {
                     name: meta.name.clone().unwrap_or_default(),


### PR DESCRIPTION
This allows to pass a lookup path with multiple crust-gather snapshots to serve under existing `serve --archive` flag. The snapshot location will be determined based on `version.yaml` file location, parent dir name of the `version.yaml` serves as a name for the cluster.

Each cluster will get its own context in the generated kubeconfig.

Example:
```yaml
clusters:
- name: crust-gather
  cluster:
    server: http://0.0.0.0:8085/crust-gather
- name: cluster-1
  cluster:
    server: http://0.0.0.0:8085/cluster-1
users:
- name: crust-gather
- name: cluster-1
contexts:
- name: crust-gather
  context:
    cluster: crust-gather
    user: crust-gather
- name: cluster-1
  context:
    cluster: cluster-1
    user: cluster-1
current-context: crust-gather
```