### PR TITLE
Disable merge queue - doesn't work with github actions bot

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,6 +1,5 @@
 name: Dependency bump automerge
 on:
-  merge_group:
   pull_request:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
     branches:

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -6,7 +6,6 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["main"]
-  merge_group:
 
 jobs:
   nix-build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["main"]
-  merge_group:
 
 env:
   # Define the rust version to use


### PR DESCRIPTION
Auto approving and merging PR performed by GitHub actions bot does not trigger actions, similar to any other GitHub workflow 
https://github.com/orgs/community/discussions/55906#discussioncomment-5946239

Requires either an app or a PAT, which is inconvenient 