### PR TITLE
Add support for label selection logic in `crust-gather serve`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +654,7 @@ dependencies = [
  "kube",
  "kube-core",
  "log",
+ "logos",
  "regex",
  "serde",
  "serde_json_path",
@@ -1518,6 +1525,39 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lzma-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ http = "1.1.0"
 serde_json_path = "0.6.4"
 base64 = "0.22.1"
 walkdir = "2.5.0"
+logos = "0.14.0"
 
 [features]
 archive = ["dep:tar", "dep:flate2", "dep:zip"]

--- a/src/gather/mod.rs
+++ b/src/gather/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod reader;
 pub mod representation;
+pub mod selector;
 pub mod server;
 pub mod writer;

--- a/src/gather/selector.rs
+++ b/src/gather/selector.rs
@@ -1,0 +1,296 @@
+use kube::Resource;
+use logos::{Lexer, Logos, Span};
+use serde::Deserialize;
+
+type Error = (String, Span);
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Selector {
+    #[serde(rename = "labelSelector")]
+    label_selector: Option<String>,
+}
+
+impl Selector {
+    pub fn matches<R: Resource>(&self, res: R) -> Option<R> {
+        match &self.label_selector {
+            Some(selector) => Expressions::try_from(selector.clone())
+                .ok()?
+                .into_iter()
+                .map(|selector| Selector::matches_selector(&selector, &res))
+                .all(|matches| matches)
+                .then_some(res),
+            None => Some(res),
+        }
+    }
+
+    fn matches_selector<R: Resource>(selector: &Expression, res: &R) -> bool {
+        let labels = res.meta().labels.as_ref();
+        let not = |found: Option<()>| match found {
+            Some(_) => None,
+            None => Some(()),
+        };
+        let exist = |key: &String| labels?.get(key).map(|_| ());
+        let value_in =
+            |key: &String, values: &Vec<String>| values.contains(labels?.get(key)?).then_some(());
+        let matches = |key: &String, value: &String| {
+            let found = labels?.get(key)? == value;
+            found.then_some(())
+        };
+
+        match selector {
+            Expression::Set(set) => match set {
+                Set::Exist(key) => exist(key),
+                Set::NotExist(key) => not(exist(key)),
+                Set::In(key, values) => value_in(key, values),
+                Set::NotIn(key, values) => not(value_in(key, values)),
+            },
+            Expression::Equality(equality) => match equality {
+                Equality::Equal(key, value) => matches(key, value),
+                Equality::NotEqual(key, value) => not(matches(key, value)),
+            },
+        }
+        .is_some()
+    }
+}
+
+pub struct Expressions(Vec<Expression>);
+
+impl IntoIterator for Expressions {
+    type Item = Expression;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"[, \t\n\f]+")]
+pub enum Expression {
+    #[regex(r"\w+\s+in\s+\([\w\s,]+\)", |lex| parse_set(lex.slice()))]
+    #[regex(r"\w+\s+notin\s+\([\w\s,]+\)", |lex| parse_set(lex.slice()))]
+    #[regex(r"\!\w+", |lex| parse_set(lex.slice()))]
+    #[regex(r"\w+", |lex| parse_set(lex.slice()))]
+    Set(Set),
+
+    #[regex(r"\w+\s*=\s*\w+", |lex| parse_equality(lex.slice()))]
+    #[regex(r"\w+\s*==\s*\w+", |lex| parse_equality(lex.slice()))]
+    #[regex(r"\w+\s*!=\s*\w+", |lex| parse_equality(lex.slice()))]
+    Equality(Equality),
+}
+
+impl TryFrom<String> for Expressions {
+    type Error = Error;
+
+    fn try_from(selector: String) -> Result<Self> {
+        let mut lexer = Expression::lexer(selector.as_str());
+        let mut expressions = vec![];
+        while let Some(value) = parse_expression(&mut lexer)? {
+            expressions.push(value);
+        }
+
+        Ok(Expressions(expressions))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Equality {
+    Equal(String, String),
+    NotEqual(String, String),
+}
+
+#[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"[ \t\n\f]+")]
+enum EqualityToken {
+    #[token("=")]
+    #[token("==")]
+    Equal,
+    #[token("!=")]
+    NotEqual,
+    #[regex(r"\w+", |lex| lex.slice().to_owned())]
+    Value(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Set {
+    Exist(String),
+    NotExist(String),
+    In(String, Vec<String>),
+    NotIn(String, Vec<String>),
+}
+
+#[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"[, \t\n\f]+")]
+enum SetToken {
+    #[token("!")]
+    Not,
+
+    #[regex(r"\([\w\s,]+\)", |lex| parse_value_list(lex.slice()))]
+    ValuesList(Vec<String>),
+
+    #[token("in")]
+    In,
+
+    #[token("notin")]
+    NotIn,
+
+    #[regex(r"\w+", |lex| lex.slice().to_owned())]
+    Value(String),
+}
+
+#[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"[, \(\)\t\n\f]+")]
+enum ValuesListToken {
+    #[regex(r"[a-zA-Z_-]+", |lex| lex.slice().to_owned())]
+    Value(String),
+}
+
+/// Parse selector expression
+pub fn parse_expression(lexer: &mut Lexer<'_, Expression>) -> Result<Option<Expression>> {
+    lexer
+        .next()
+        .map(|token| match token {
+            Ok(Expression::Equality(eq)) => Ok(Expression::Equality(eq)),
+            Ok(Expression::Set(set)) => Ok(Expression::Set(set)),
+            _ => Err(("unexpected expression".to_owned(), lexer.span())),
+        })
+        .transpose()
+}
+
+/// Parse an equality based expression.
+fn parse_equality(source: &str) -> Option<Equality> {
+    let mut lexer = EqualityToken::lexer(source);
+    let key = lexer.next()?.ok()?;
+    let op = lexer.next()?.ok()?;
+    let value = lexer.next()?.ok()?;
+    match (key, op, value) {
+        (EqualityToken::Value(key), EqualityToken::Equal, EqualityToken::Value(value)) => {
+            Some(Equality::Equal(key, value))
+        }
+        (EqualityToken::Value(key), EqualityToken::NotEqual, EqualityToken::Value(value)) => {
+            Some(Equality::NotEqual(key, value))
+        }
+        _ => None,
+    }
+}
+
+/// Parse a set based expression.
+fn parse_set(source: &str) -> Option<Set> {
+    let mut lexer = SetToken::lexer(source);
+    let key = lexer.next()?.ok()?;
+    match key {
+        SetToken::Not => match lexer.next()?.ok()? {
+            SetToken::Value(value) => Some(Set::NotExist(value)),
+            _ => None,
+        },
+        SetToken::Value(key) => {
+            let op = match lexer.next() {
+                Some(op) => op.ok()?,
+                None => return Some(Set::Exist(key)),
+            };
+            let value = lexer.next()?.ok()?;
+            match (op, value) {
+                (SetToken::In, SetToken::ValuesList(values)) => Some(Set::In(key, values)),
+                (SetToken::NotIn, SetToken::ValuesList(values)) => Some(Set::NotIn(key, values)),
+                (_, _) => None,
+            }
+        }
+        SetToken::ValuesList(_) | SetToken::In | SetToken::NotIn => None,
+    }
+}
+
+// Parse a list of values into vector
+fn parse_value_list(source: &str) -> Option<Vec<String>> {
+    let lexer = ValuesListToken::lexer(source);
+    let mut values = vec![];
+    for value in lexer {
+        values.push(match value.ok()? {
+            ValuesListToken::Value(value) => value,
+        });
+    }
+
+    Some(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use logos::Logos;
+
+    use super::{parse_expression, parse_value_list, Equality, Expression, Set};
+
+    #[test]
+    fn values_lexer() {
+        assert_eq!(
+            Some(vec!["a".into(), "b".into(), "c".into()]),
+            parse_value_list(" (a,b, c)")
+        );
+        assert_eq!(Some(vec!["a".into()]), parse_value_list("(a)"));
+        assert_eq!(Some(vec![]), parse_value_list("()"));
+        assert_eq!(Some(vec![]), parse_value_list(""));
+    }
+
+    #[test]
+    fn expression_lexer() {
+        let data = "a==b,,b=c,c!=d,a in (a,b, c), a notin (a), c,!a,a()d";
+        let mut lexer = Expression::lexer(data);
+        assert_eq!(
+            Some(Expression::Equality(Equality::Equal(
+                "a".into(),
+                "b".into()
+            ))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Equality(Equality::Equal(
+                "b".into(),
+                "c".into()
+            ))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Equality(Equality::NotEqual(
+                "c".into(),
+                "d".into()
+            ))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::In(
+                "a".into(),
+                vec!["a".into(), "b".into(), "c".into()]
+            ))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::NotIn("a".into(), vec!["a".into()]))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::Exist("c".into()))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::NotExist("a".into()))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::Exist("a".into()))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(
+            Some(("unexpected expression".into(), 49..50)),
+            parse_expression(&mut lexer).err()
+        );
+        assert_eq!(
+            Some(("unexpected expression".into(), 50..51)),
+            parse_expression(&mut lexer).err()
+        );
+        assert_eq!(
+            Some(Expression::Set(Set::Exist("d".into()))),
+            parse_expression(&mut lexer).unwrap()
+        );
+        assert_eq!(None, parse_expression(&mut lexer).unwrap());
+    }
+}

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -19,7 +19,7 @@ use crate::gather::{
     writer::Archive,
 };
 
-use super::{reader::Selector, representation::ArchivePath, writer::ArchiveSearch};
+use super::{representation::ArchivePath, selector::Selector, writer::ArchiveSearch};
 
 #[derive(Clone, Deserialize)]
 pub struct Socket(SocketAddr);

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -19,7 +19,7 @@ use crate::gather::{
     writer::Archive,
 };
 
-use super::{representation::ArchivePath, writer::ArchiveSearch};
+use super::{reader::Selector, representation::ArchivePath, writer::ArchiveSearch};
 
 #[derive(Clone, Deserialize)]
 pub struct Socket(SocketAddr);
@@ -238,10 +238,11 @@ async fn apis(
 async fn api_list(
     accept: Header<Accept>,
     list: Path<List>,
+    query: Query<Selector>,
     reader: web::Data<HashMap<String, Reader>>,
 ) -> actix_web::Result<impl Responder> {
     Ok(web::Json(
-        list_items(accept, list, reader).map_err(error::ErrorNotFound)?,
+        list_items(accept, list, query, reader).map_err(error::ErrorNotFound)?,
     ))
 }
 
@@ -249,10 +250,11 @@ async fn api_list(
 async fn apis_list(
     accept: Header<Accept>,
     list: Path<List>,
+    query: Query<Selector>,
     reader: web::Data<HashMap<String, Reader>>,
 ) -> actix_web::Result<impl Responder> {
     Ok(web::Json(
-        list_items(accept, list, reader).map_err(error::ErrorNotFound)?,
+        list_items(accept, list, query, reader).map_err(error::ErrorNotFound)?,
     ))
 }
 
@@ -260,10 +262,11 @@ async fn apis_list(
 async fn api_namespaced_list(
     accept: Header<Accept>,
     list: Path<List>,
+    query: Query<Selector>,
     reader: web::Data<HashMap<String, Reader>>,
 ) -> actix_web::Result<impl Responder> {
     Ok(web::Json(
-        list_items(accept, list, reader).map_err(error::ErrorNotFound)?,
+        list_items(accept, list, query, reader).map_err(error::ErrorNotFound)?,
     ))
 }
 
@@ -271,16 +274,18 @@ async fn api_namespaced_list(
 async fn apis_namespaced_list(
     accept: Header<Accept>,
     list: Path<List>,
+    query: Query<Selector>,
     reader: web::Data<HashMap<String, Reader>>,
 ) -> actix_web::Result<impl Responder> {
     Ok(web::Json(
-        list_items(accept, list, reader).map_err(error::ErrorNotFound)?,
+        list_items(accept, list, query, reader).map_err(error::ErrorNotFound)?,
     ))
 }
 
 fn list_items(
     accept: Header<Accept>,
     list: Path<List>,
+    query: Query<Selector>,
     reader: web::Data<HashMap<String, Reader>>,
 ) -> anyhow::Result<serde_json::Value> {
     let server = reader
@@ -288,9 +293,9 @@ fn list_items(
         .ok_or(anyhow::anyhow!("Server not found"))?;
     Ok(match accept.0.as_slice() {
         [QualityItem { item, .. }, ..] if item.to_string().contains("as=Table") => {
-            server.load_table(list.clone())?
+            server.load_table(list.clone(), query.0)?
         }
-        _ => server.load_list(list.clone())?,
+        _ => server.load_list(list.clone(), query.0)?,
     })
 }
 


### PR DESCRIPTION
Allow to pass label selectors on the listed objects, which will be processed by `crust-gather serve` as a regular API server would.

```bash
$ kubectl get secrets -n cattle-system -l='!owner'
NAME                                  TYPE                                  DATA   AGE
bootstrap-secret                      Opaque                                1      4d4h
cattle-webhook-ca                     kubernetes.io/tls                     2      4d4h
cattle-webhook-tls                    kubernetes.io/tls                     2      4d4h
git-webhook-api-service-token-cfpgt   kubernetes.io/service-account-token   3      4d4h
rancher-token-62tlb                   kubernetes.io/service-account-token   3      4d4h
serving-cert                          kubernetes.io/tls                     2      4d4h
tls-rancher                           kubernetes.io/tls                     2      4d4h
tls-rancher-ingress                   kubernetes.io/tls                     3      4d4h
tls-rancher-internal                  kubernetes.io/tls                     2      4d4h
tls-rancher-internal-ca               kubernetes.io/tls                     2      4d4h
$ kubectl get secrets  -l='owner in (helm, other),owner=helm,!test' -n cattle-system
NAME                                    TYPE                 DATA   AGE
sh.helm.release.v1.rancher-webhook.v1   helm.sh/release.v1   1      4d4h
sh.helm.release.v1.rancher-webhook.v2   helm.sh/release.v1   1      4d4h
sh.helm.release.v1.rancher-webhook.v3   helm.sh/release.v1   1      4d4h
sh.helm.release.v1.rancher.v1           helm.sh/release.v1   1      4d4h
$ crust-gather collect
…
$ crust-gather serve &
$ kubectl get secrets  -l='owner in (helm, other),owner=helm,!test' -n cattle-system
NAME
sh.helm.release.v1.rancher-webhook.v1
sh.helm.release.v1.rancher-webhook.v2
sh.helm.release.v1.rancher-webhook.v3
sh.helm.release.v1.rancher.v1
$ kubectl get secrets -n cattle-system -l='!owner'
NAME
bootstrap-secret
cattle-webhook-ca
cattle-webhook-tls
git-webhook-api-service-token-cfpgt
rancher-token-62tlb
serving-cert
tls-rancher-ingress
tls-rancher-internal-ca
tls-rancher-internal
tls-rancher
```