### PR TITLE
Fix json-path table escape for \., improve logging

### DIFF
--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use json_patch::{patch, AddOperation, PatchOperation, ReplaceOperation};
 use jsonptr::Pointer;
 use k8s_openapi::{
@@ -181,9 +181,12 @@ struct TablePath {
 
 impl TablePath {
     fn new(column: &CustomResourceColumnDefinition) -> anyhow::Result<Self> {
+        let json_path = format!("${}", column.json_path.replace(r"\.", r"."));
+        let json_path = JsonPath::parse(&json_path)
+            .map_err(|e| anyhow!("unable to parse json path for {json_path}: {e:?}",))?;
         Ok(Self {
             column: column.clone(),
-            json_path: JsonPath::parse(format!("${}", column.json_path).as_str())?,
+            json_path,
         })
     }
 


### PR DESCRIPTION
Incorrect escaping causes to surface error similar to:
```
I0712 12:20:40.750136 2107362 helpers.go:246] server response object: [{
  "metadata": {},
  "status": "Failure",
  "message": "Unable to list \"infrastructure.cluster.x-k8s.io/v1beta1, Resource=dockerclusters\": the server could not find the requested resource (get dockerclusters.infrastructure.cluster.x-k8s.io)",
  "reason": "NotFound",
  "details": {
    "group": "infrastructure.cluster.x-k8s.io",
    "kind": "dockerclusters",
    "causes": [
      {
        "reason": "UnexpectedServerResponse",
        "message": "unable to parse json path for $.metadata.labels['cluster\\.x-k8s\\.io/cluster-name']: ParseError { err: ErrorImpl { position: 26, message: \"in long-hand segment, expected an ending quote\" } }"
      }
    ]
  },
  "code": 404
}]
```