### PR TITLE
Refactor to utilize `NamespaceName` and `TypeMetaGetter`

### DIFF
--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -390,7 +390,7 @@ fn watch_response(
             for event in watch_events(accept.clone(), list.clone(), query.clone(), &reader)? {
                 yield publish(event);
             }
-            let next_event_time = reader.next_patch_time.replace(Duration::MAX);
+            let next_event_time = reader.pop_next_event_time();
             if next_event_time == Duration::MAX {
                 break;
             }

--- a/src/scanners/events.rs
+++ b/src/scanners/events.rs
@@ -5,7 +5,7 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::Time,
     chrono::{DateTime, Utc},
 };
-use kube::core::{ApiResource, TypeMeta};
+use kube::core::ApiResource;
 use kube::Api;
 use std::{
     fmt::Debug,
@@ -34,7 +34,7 @@ impl Debug for Events {
 impl From<Config> for Events {
     fn from(value: Config) -> Self {
         Self {
-            collectable: Objects::new_typed(value, ApiResource::erase::<Event>(&())),
+            collectable: Objects::new_typed(value),
         }
     }
 }
@@ -130,8 +130,8 @@ impl Collect<Event> for Events {
         self.collectable.get_api()
     }
 
-    fn get_type_meta(&self) -> TypeMeta {
-        self.collectable.get_type_meta()
+    fn resource(&self) -> ApiResource {
+        self.collectable.resource()
     }
 
     async fn collect(&self) -> anyhow::Result<()> {

--- a/src/scanners/info.rs
+++ b/src/scanners/info.rs
@@ -6,7 +6,7 @@ use std::{
 use async_trait::async_trait;
 use http::Request;
 use k8s_openapi::{api::core::v1::Node, chrono::Utc};
-use kube::core::{ApiResource, TypeMeta};
+use kube::core::ApiResource;
 use kube::Api;
 
 use crate::gather::{
@@ -25,7 +25,7 @@ pub struct Info {
 impl Info {
     pub fn new(config: Config) -> Self {
         Self {
-            collectable: Objects::new_typed(config, ApiResource::erase::<Node>(&())),
+            collectable: Objects::new_typed(config),
         }
     }
 }
@@ -98,7 +98,7 @@ impl Collect<Node> for Info {
         self.collectable.get_api()
     }
 
-    fn get_type_meta(&self) -> TypeMeta {
-        self.collectable.get_type_meta()
+    fn resource(&self) -> ApiResource {
+        self.collectable.resource()
     }
 }

--- a/src/scanners/versions.rs
+++ b/src/scanners/versions.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use k8s_openapi::api::core::v1::Pod;
-use kube::core::{ApiResource, TypeMeta};
+use kube::core::ApiResource;
 use kube::{Api, Resource};
 use serde::Serialize;
 
@@ -33,7 +33,7 @@ pub struct Versions {
 impl Versions {
     pub fn new(config: Config) -> Self {
         Self {
-            collectable: Objects::new_typed(config, ApiResource::erase::<Pod>(&())),
+            collectable: Objects::new_typed(config),
         }
     }
 }
@@ -79,8 +79,8 @@ impl Collect<Pod> for Versions {
         self.collectable.get_api()
     }
 
-    fn get_type_meta(&self) -> TypeMeta {
-        self.collectable.get_type_meta()
+    fn resource(&self) -> ApiResource {
+        self.collectable.resource()
     }
 }
 


### PR DESCRIPTION
Convenience interfaces for future refactors.

Original idea was to mitigate k9s problem with requesting resources with wrong version, if the `apis.json` returned by real API server gave them wrong for whatever reason. Collected archive inherits the problems of the real cluster.

For now, a kubectl can be used, which relies solely on CRD versions, and the problem is known. Don’t want to complicate things.

Ideas wanted to explore:
- Use `client` instead of API for the resource collection (problematic with `DynamicObject`). Alternatively, `get_api` can be specialized with something like this: https://github.com/stackabletech/operator-rs/blob/1c2d22c7be99e833678beaf159e99638a9e6d3db/crates/stackable-operator/src/client.rs#L550-L623 (it’s just beautiful)
