### PR TITLE
Bump rust version, and display event contents

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Define the rust version to use
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.80.1
   # Rust build arguments
   BUILD_ARGS: "--release --features=archive"
   # The binary name


### PR DESCRIPTION
Allows for a better display of cluster events in a table format, as opposed to just `NAME` field previously. Since events are internal resource, the table representation for it is custom.

```
kubectl get events 
NAME                                                                   LASTTIMESTAMP          TYPE      REASON                     OBJECT                                                                 MESSAGE
fleet-addon-config.17ed7d5514738848                                    2024-08-20T16:40:36Z   Warning   OwnerRefInvalidNamespace   fleet-addon-config.17ed7d5514738848                                    ownerRef [operator.cluster.x-k8s.io/v1alpha2/AddonProvider, namespace: , name: fleet, uid: 7e669c0b-fb01-411d-a831-f67dc5a7a1ea] does not exist in namespace ""
```