### PR TITLE
Add krew release bot step to publish to krew-index

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,3 +142,5 @@ jobs:
           args: release --skip=validate --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -37,8 +37,39 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  shortDescription: Provides functionality similar to os adm inspect, by collecting all resources for debugging purposes, and serving them via simple api-server.
+  shortDescription: Collect cluster state and serve it via an API server
   description: |
-    Provides functionality similar to os adm inspect, by collecting all resources for debugging purposes. Later, the archive can be served
-    with an api-server to explore the content using regular clients, like kubectl or k9s.
+    `crust-gather` is a useful cluster debugging tool.
+    It allows user to collect full or partial cluster state
+    via a selection of filters. The desired set of resources
+    can be reduced or extended based on GVK or namespace
+    selection.
 
+    `crust-gather` collects pod logs across the cluster.
+    The tool also allows collecting custom logs from
+    the node itself, such as kubelet logs.
+
+    It is a common requirement to remove secret data from the
+    output, so `crust-gather` provides flags and configuration
+    options to exclude secret data from any collected content.
+
+    ```bash
+    $ kubectl crust-gather collect --help
+    $ kubectl crust-gather collect
+    ```
+
+    To simplify the debugging process, `crust-gather` supports
+    serving the collected archive via an embedded API server
+    replica, which is compatible with kubectl or k9s clients.
+
+    ```bash
+    $ kubectl crust-gather serve --help
+    $ kubectl crust-gather serve &
+    ```
+  caveats: |
+    * Serving the archive overrides current KUBECONFIG
+      or the ~/.kube/config file.
+    * Tool is intended for cluster administrators, with
+      high RBAC privileges, or test (temporary) clusters.
+    * Cluster-wide watch recording and replaying functionality
+      is also supported, but it is best effort only.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Depending on the installation type, there might be needed:
 The plugin can be installed with `krew` and used as follows:
 
 ```bash
-kubectl krew index add crust-gather https://github.com/crust-gather/crust-gather.git
-kubectl krew install crust-gather/crust-gather
+kubectl krew install crust-gather
 
 kubectl crust-gather --help
 ```


### PR DESCRIPTION
According to https://github.com/rajatjindal/krew-release-bot?tab=readme-ov-file#example-when-using-go-releaser this should enable automatic release publish after https://github.com/kubernetes-sigs/krew-index/pull/4041 merges.