### PR TITLE
Merge kubeconfigs to avoid errasing default kubeconfig file on serve

### DIFF
--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -110,7 +110,7 @@ impl Api {
             .clone()
             .into_iter()
             .map(|a| Api::prepare_kubeconfig(&a, socket))
-            .try_fold(Kubeconfig::default(), Kubeconfig::merge)?;
+            .try_fold(Kubeconfig::read().unwrap_or_default(), Kubeconfig::merge)?;
 
         let kubeconfig_path = kubeconfig.unwrap_or(std::path::PathBuf::from(
             std::env::var("KUBECONFIG")

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -182,7 +182,10 @@ impl Api {
         config.clusters.retain(|c| !contexts.contains(&c.name));
         config.auth_infos.retain(|ai| !contexts.contains(&ai.name));
 
-        config.current_context = state.previous_context;
+        config.current_context = match config.contexts.iter().find(|c| Some(c.name.clone()) == state.previous_context) {
+            Some(context) => Some(context.name.clone()),
+            None => config.contexts.first().map(|c| c.name.clone())
+        };
 
         serde_yaml::to_writer(File::create(state.kubeconfig_path)?, &config)?;
 


### PR DESCRIPTION
If you do not set $KUBECONFIG or provide --kubeconfig, the default kubeconfig is overwritten when you start serve command.

This PR merge the exisiting kubeconfig with the contexts added by crust-gather and remove these contexts on shutdown.