### PR TITLE
Use all versions for collection, not only preferred

### DIFF
--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -365,7 +365,7 @@ impl Config {
         };
         let collectables = discovery
             .groups()
-            .flat_map(kube::discovery::ApiGroup::recommended_resources)
+            .flat_map(|r| r.resources_by_stability())
             .filter_map(|r| r.1.supports_operation(mode).then_some(r.0.into()))
             .flat_map(|group: Group| group.into_collectable(self.clone()));
 


### PR DESCRIPTION
In the situations when there are multiple resources of different versions in the same group, collection simply skipped older versions then preferred.

This is fine for the case of outdated or non-served API version, but it may also appear in scenario when entirely differen CRD is using same group but is behind in the version. For this scenario, collection needs to be exhaustive.

Fixes #185