### PR TITLE
Use goreleaser version 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - main: hack/goreleaser.go
     id: kubectl-crust-gather


### PR DESCRIPTION
This should eliminate the following error message when running the release CI [job](https://github.com/crust-gather/crust-gather/actions/runs/12007004976/job/33467267188#step:7:21):
```
only configurations files on  version: 2  are supported, yours is
version: 0 , please update your configuration
```

Tested locally with `goreleaser check`.