### PR TITLE
fix: Apple Silicon support install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -222,8 +222,8 @@ detect_arch() {
   arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
   case "${arch}" in
-    amd64) arch="amd64" ;;
-    arm64) arch="arm64" ;;
+    x86_64|amd64)  arch="x86_64" ;;
+    arm64|aarch64) arch="aarch64" ;;
   esac
 
   printf '%s' "${arch}"


### PR DESCRIPTION
Summary
Normalize detect_arch so that arm64 → aarch64. This fixes the installer falsely rejecting Apple Silicon (arm64-apple-darwin) as unsupported, even though builds are published.

Details

Updated detect_arch to map arm64|aarch64 → aarch64, amd64|x86_64 → x86_64.

Ensures ORIGIN_TARGET matches the Rust-style triples in SUPPORTED_TARGETS.

Keeps correct_target logic intact, so download URLs still resolve to *_darwin_arm64 / *_linux_arm64.

No impact on Linux ARM64 builds.

Apple Silicon is now recognized as supported, and installer successfully downloads the correct release asset.

Fixes #310