### PR TITLE
Add SOCKS5 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1283,7 +1284,9 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
  "tokio",
@@ -1484,6 +1487,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.0"
 edition = "2024"
 
 [dependencies]
-kube = { version = "2.0.0", features = ["ws"] }
+kube = { version = "2.0.0", features = ["socks5", "ws"] }
 k8s-openapi = { version = "0.26.0", features = ["latest"] }
 tokio = { version = "1.47.1", features = ["full"] }
 serde_yaml = "0.9.28"


### PR DESCRIPTION
Add support for using a SOCKS5 proxy to reach the Kubernetes API.

An example Kubeconfig snippet using this feature:

```yaml
apiVersion: v1
kind: Config
clusters:
- name: "my-cluster"
  cluster:
    server: "https://10.0.0.1:6443"
    proxy-url: socks5://localhost:1080
```