### PR TITLE
Allow setting systemd units name to collect kubelet logs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,6 +260,11 @@ impl GatherSettings {
             },
             secrets_file: other.secrets_file.or(self.secrets_file.clone()),
             duration: other.duration.or(self.duration),
+            systemd_units: if other.systemd_units.is_empty() {
+                self.systemd_units.clone()
+            } else {
+                other.systemd_units
+            },
         }
     }
 }
@@ -344,6 +349,17 @@ pub struct GatherSettings {
         value_parser = |arg: &str| -> anyhow::Result<RunDuration> {Ok(RunDuration::try_from(arg.to_string())?)})]
     #[serde(default)]
     duration: Option<RunDuration>,
+
+    /// Name of the kubelet systemd unit.
+    ///
+    /// Defaults to kubelet.
+    ///
+    /// Example:
+    ///     --systemd-unit=rke2-server
+    ///     --systemd-unit=rke2-agent
+    #[arg(long = "systemd-unit", value_name = "SYSTEMD_UNIT", default_value = "kubelet", action = ArgAction::Append )]
+    #[serde(default)]
+    systemd_units: Vec<String>,
 }
 
 impl GatherSettings {
@@ -587,6 +603,7 @@ impl GatherCommands {
                 .map(Into::into)
                 .collect(),
             self.settings.duration.unwrap_or_default(),
+            self.settings.systemd_units.clone(),
         ))
     }
 

--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -332,6 +332,7 @@ pub struct Config {
     pub mode: GatherMode,
     pub additional_logs: Vec<CustomLog>,
     duration: RunDuration,
+    pub systemd_units: Vec<String>,
 }
 
 impl Config {
@@ -343,6 +344,7 @@ impl Config {
         mode: GatherMode,
         additional_logs: Vec<CustomLog>,
         duration: RunDuration,
+        systemd_units: Vec<String>,
     ) -> Self {
         Self {
             client,
@@ -352,6 +354,7 @@ impl Config {
             mode,
             additional_logs,
             writer: writer.into(),
+            systemd_units,
         }
     }
 
@@ -645,6 +648,7 @@ mod tests {
             mode: GatherMode::Collect,
             secrets: Default::default(),
             additional_logs: Default::default(),
+            systemd_units: Default::default(),
         };
 
         let result = config.collect().await;

--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -587,6 +587,7 @@ mod tests {
             mode: GatherMode::Collect,
             duration: "10s".to_string().try_into().unwrap(),
             additional_logs: Default::default(),
+            systemd_units: Default::default(),
         };
 
         // Gzip archive is failing due to timeout.
@@ -619,6 +620,7 @@ mod tests {
             mode: GatherMode::Collect,
             secrets: Default::default(),
             additional_logs: Default::default(),
+            systemd_units: Default::default(),
         };
 
         let result = config.collect().await;

--- a/src/gather/representation.rs
+++ b/src/gather/representation.rs
@@ -356,7 +356,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let log_group = LogGroup::Kubelet;
+        let log_group = LogGroup::Kubelet(String::from("kubelet"));
 
         let result = ArchivePath::logs_path(&resource, TypeMeta::resource::<Node>(), log_group);
 

--- a/src/gather/representation.rs
+++ b/src/gather/representation.rs
@@ -107,7 +107,7 @@ impl From<UserLog> for CustomLog {
 pub enum LogGroup {
     Current(Container),
     Previous(Container),
-    Kubelet,
+    Kubelet(String),
     KubeletLegacy,
     Custom(CustomLog),
 }
@@ -117,7 +117,7 @@ impl fmt::Display for LogGroup {
         match self {
             Self::Current(container) => write!(formatter, "{container:?}/current.log"),
             Self::Previous(container) => write!(formatter, "{container:?}/previous.log"),
-            Self::Kubelet => write!(formatter, "kubelet.log"),
+            Self::Kubelet(systemd_unit) => write!(formatter, "{systemd_unit}.log"),
             Self::KubeletLegacy => write!(formatter, "kubelet-log-path.log"),
             Self::Custom(CustomLog { path, .. }) => write!(formatter, "{path}"),
         }
@@ -183,7 +183,7 @@ impl ArchivePath {
                 LogGroup::Previous(Container(container)) => {
                     ArchivePath::Logs(path.with_extension("").join(container).join("previous.log"))
                 }
-                LogGroup::Kubelet => ArchivePath::Logs(path.with_extension("").join("kubelet.log")),
+                LogGroup::Kubelet(systemd_unit) => ArchivePath::Logs(path.with_extension("").join(format!("{systemd_unit}.log"))),
                 LogGroup::KubeletLegacy => {
                     ArchivePath::Logs(path.with_extension("").join("kubelet-log-path.log"))
                 }

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -169,6 +169,7 @@ mod test {
                     GatherMode::Collect,
                     Default::default(),
                     "1m".to_string().try_into().unwrap(),
+                    Default::default(),
                 ),
                 ApiResource::erase::<Pod>(&()),
             ),

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -232,6 +232,7 @@ mod test {
                 GatherMode::Collect,
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
+                Default::default(),
             )),
             group: LogSelection::Current,
         }

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -191,6 +191,7 @@ mod test {
                 GatherMode::Collect,
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
+                Default::default(),
             ),
             ApiResource::erase::<Pod>(&()),
         )
@@ -227,6 +228,7 @@ mod test {
                 GatherMode::Collect,
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
+                Default::default(),
             ),
             ApiResource::erase::<Namespace>(&()),
         );
@@ -260,6 +262,7 @@ mod test {
                 GatherMode::Collect,
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
+                Default::default(),
             ),
             ApiResource::erase::<Pod>(&()),
         );


### PR DESCRIPTION
Some kubernetes distribution do not use `kubelet` as systemd unit name by default which prevent collecting kubelet logs.

For example:
- `k3s` on k3s master nodes and `k3s-agent` on k3s worker nodes
- `rke2-server` and `rke2-agent` for rke2
- ...

This PR adds a parameter to provide a list of systemd units to get logs from. By default it remains kubelet.

The collected logs are stored in a file <the systemd-unit-name>.log in the node directory.