### PR TITLE
Allow setting debug pod image

### DIFF
--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -11,7 +11,7 @@ use duration_string::DurationString;
 use futures::future::join_all;
 use k8s_openapi::api::core::v1::{ConfigMap, Event, Node, Pod, Secret};
 use kube::api::ListParams;
-use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::config::Kubeconfig;
 use kube::core::discovery::verbs::{LIST, WATCH};
 use kube::core::ApiResource;
 use kube::{discovery, Api, Client, ResourceExt};
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use tokio::time::timeout;
 use tracing::instrument;
 
+use crate::cli::DebugPod;
 use crate::filters::filter::FilterGroup;
 use crate::scanners::dynamic::Dynamic;
 use crate::scanners::events::Events;
@@ -329,6 +330,7 @@ pub struct Config {
     pub additional_logs: Vec<CustomLog>,
     duration: RunDuration,
     pub systemd_units: Vec<String>,
+    pub debug_pod: DebugPod,
 }
 
 impl Config {
@@ -341,6 +343,7 @@ impl Config {
         additional_logs: Vec<CustomLog>,
         duration: RunDuration,
         systemd_units: Vec<String>,
+        debug_pod: DebugPod,
     ) -> Self {
         Self {
             client,
@@ -351,6 +354,7 @@ impl Config {
             additional_logs,
             writer: writer.into(),
             systemd_units,
+            debug_pod,
         }
     }
 
@@ -580,6 +584,7 @@ mod tests {
             duration: "10s".to_string().try_into().unwrap(),
             additional_logs: Default::default(),
             systemd_units: Default::default(),
+            debug_pod: Default::default(),
         };
 
         // Gzip archive is failing due to timeout.
@@ -609,6 +614,7 @@ mod tests {
             secrets: Default::default(),
             additional_logs: Default::default(),
             systemd_units: Default::default(),
+            debug_pod: Default::default(),
         };
 
         let result = config.collect().await;
@@ -635,6 +641,7 @@ mod tests {
             secrets: Default::default(),
             additional_logs: Default::default(),
             systemd_units: Default::default(),
+            debug_pod: Default::default(),
         };
 
         let result = config.collect().await;

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -166,6 +166,7 @@ mod test {
                     Default::default(),
                     "1m".to_string().try_into().unwrap(),
                     Default::default(),
+                    Default::default(),
                 ),
                 ApiResource::erase::<Pod>(&()),
             ),

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -228,6 +228,7 @@ mod test {
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
                 Default::default(),
+                Default::default(),
             )),
             group: LogSelection::Current,
         }

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -100,6 +100,7 @@ impl<R: ResourceThreadSafe> Collect<R> for Objects<R> {
     fn resource(&self) -> ApiResource {
         self.resource.clone()
     }
+
 }
 
 #[cfg(test)]
@@ -188,6 +189,7 @@ mod test {
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
                 Default::default(),
+                Default::default(),
             ),
             ApiResource::erase::<Pod>(&()),
         )
@@ -221,6 +223,7 @@ mod test {
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
                 Default::default(),
+                Default::default(),
             ),
             ApiResource::erase::<Namespace>(&()),
         );
@@ -250,6 +253,7 @@ mod test {
                 GatherMode::Collect,
                 Default::default(),
                 "1m".to_string().try_into().unwrap(),
+                Default::default(),
                 Default::default(),
             ),
             ApiResource::erase::<Pod>(&()),

--- a/src/scanners/user_logs.rs
+++ b/src/scanners/user_logs.rs
@@ -19,6 +19,7 @@ use kube::{
 use tracing::instrument;
 
 use crate::{
+    cli::DebugPod,
     gather::{
         config::{Config, Secrets},
         representation::{ArchivePath, CustomLog, LogGroup, Representation},
@@ -37,6 +38,7 @@ use super::{
 pub struct UserLogs {
     pub collectable: Objects<Node>,
     pub logs: Vec<CustomLog>,
+    pub debug_pod: DebugPod,
 }
 
 impl Debug for UserLogs {
@@ -49,6 +51,7 @@ impl From<Config> for UserLogs {
     fn from(value: Config) -> Self {
         Self {
             logs: value.additional_logs.clone(),
+            debug_pod: value.debug_pod.clone(),
             collectable: Objects::new_typed(value),
         }
     }
@@ -77,7 +80,7 @@ impl Collect<Node> for UserLogs {
 
         let mut pods = vec![];
         for log in self.logs.deref() {
-            let pod = Nodes::get_template_pod(log.path.clone(), node_name.clone());
+            let pod = Nodes::get_template_pod(&self.debug_pod, log.path.clone(), node_name.clone());
             pods.push(pod.clone());
             self.get_or_create(pod).await?;
         }


### PR DESCRIPTION
The pod which is used to collect logs from nodes is not configurable.
Even if it's possible to start it on each node prior to run crustgather collect, I would prefer to be able to configure it.

In my case I just need to set the image as I cannot run `latest` images (without modifying few policies) but I imagine others may need some other parameters.

So In this PR I added a `DebugPod` object in the config with only `image` for now which can be set using `--debug-pod-image`.
The default value is `busybox` as it was hard coded.