### PR TITLE
Use crates.io envtest and simplify kube client setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,8 +870,9 @@ dependencies = [
 
 [[package]]
 name = "envtest"
-version = "0.1.0"
-source = "git+https://github.com/Danil-Grigorev/envtest?rev=18eb36f209da#18eb36f209da66179533c1a203a6d53e9ee19835"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8716f09166d28a4e95ce3a84a6a21288a32b8399596de141b932dce97b79e4e"
 dependencies = [
  "rust2go",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ xid = "1.1.1"
 tempdir = "0.3.7"
 serial_test = "3.2.0"
 serde_with = "3.14.1"
-envtest = { git = "https://github.com/Danil-Grigorev/envtest", rev = "18eb36f209da" }
+envtest = "0.0.1"
 
 [profile.release]
 strip = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -876,13 +876,7 @@ mod tests {
     async fn test_collect_from_config_map() {
         let test_env = envtest::Environment::default().create().expect("cluster");
         let config: Kubeconfig = test_env.kubeconfig().unwrap();
-        let cfg = kube::config::Config::from_custom_kubeconfig(
-            config.clone(),
-            &KubeConfigOptions::default(),
-        )
-        .await
-        .unwrap();
-        let client = Client::try_from(cfg).unwrap();
+        let client: Client = config.clone().try_into().unwrap();
 
         let valid_config = r"
             filters:
@@ -948,13 +942,7 @@ mod tests {
             .create()
             .expect("cluster one");
         let config: Kubeconfig = test_env.kubeconfig().unwrap();
-        let cfg = kube::config::Config::from_custom_kubeconfig(
-            config.clone(),
-            &KubeConfigOptions::default(),
-        )
-        .await
-        .unwrap();
-        let client = Client::try_from(cfg).unwrap();
+        let client: Client = config.clone().try_into().unwrap();
 
         let other_env = envtest::Environment::default()
             .create()
@@ -1112,13 +1100,7 @@ mod tests {
             .create()
             .expect("cluster one");
         let config: Kubeconfig = test_env.kubeconfig().unwrap();
-        let cfg = kube::config::Config::from_custom_kubeconfig(
-            config.clone(),
-            &KubeConfigOptions::default(),
-        )
-        .await
-        .unwrap();
-        let client = Client::try_from(cfg).unwrap();
+        let client: Client = config.clone().try_into().unwrap();
 
         let other_env = envtest::Environment::default()
             .create()

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -155,7 +155,7 @@ mod test {
     use std::time::Duration;
 
     use k8s_openapi::{api::core::v1::Pod, serde_json};
-    use kube::config::KubeConfigOptions;
+    use kube::config::{KubeConfigOptions, Kubeconfig};
     use kube::core::params::PostParams;
     use kube::Api;
     use serial_test::serial;
@@ -182,15 +182,10 @@ mod test {
     #[serial]
     async fn collect_logs() {
         let test_env = envtest::Environment::default().create().expect("cluster");
-        let cfg = kube::config::Config::from_custom_kubeconfig(
-            test_env.kubeconfig().expect("kubeconfig"),
-            &KubeConfigOptions::default(),
-        )
-        .await
-        .expect("config");
+        let config: Kubeconfig = test_env.kubeconfig().expect("kubeconfig");
         let filter = NamespaceInclude::try_from("default".to_string()).unwrap();
 
-        let pod_api: Api<Pod> = Api::default_namespaced(cfg.clone().try_into().expect("client"));
+        let pod_api: Api<Pod> = Api::default_namespaced(config.clone().try_into().expect("client"));
 
         let pod = timeout(
             Duration::new(10, 0),
@@ -224,7 +219,7 @@ mod test {
         let file_path = tmp_dir.path().join("crust-gather-test");
         let repr = Logs {
             collectable: Objects::new_typed(Config::new(
-                cfg.clone().try_into().expect("client"),
+                config.try_into().expect("client"),
                 FilterGroup(vec![FilterList(vec![vec![filter].into()])]),
                 Writer::new(&Archive::new(file_path), &Encoding::Path)
                     .expect("failed to create builder"),

--- a/src/scanners/versions.rs
+++ b/src/scanners/versions.rs
@@ -138,14 +138,10 @@ mod tests {
         );
         valid.write_all(valid_config.as_bytes()).unwrap();
 
-        let cfg = kube::config::Config::from_custom_kubeconfig(
-            test_env.kubeconfig().expect("kubeconfig"),
-            &KubeConfigOptions::default(),
-        )
-        .await
-        .expect("config");
+        let config: Kubeconfig = test_env.kubeconfig().expect("kubeconfig");
+        let client = config.try_into().expect("client");
 
-        let pod_api: Api<Pod> = Api::default_namespaced(cfg.try_into().expect("client"));
+        let pod_api: Api<Pod> = Api::default_namespaced(client);
         timeout(
             Duration::new(10, 0),
             Retry::spawn(FixedInterval::new(Duration::from_secs(1)), || async {


### PR DESCRIPTION
- Switch `envtest` to the freshly published 0.0.1 crates.io release instead of the pinned git rev.
- Adopt the new `Kubeconfig::try_into() → Client` conversion that landed with `kube` 2.0 and simplify tests setup code.