### PR TITLE
Fix name deductions parsing api(s) files

### DIFF
--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -11,7 +11,7 @@ use duration_string::DurationString;
 use futures::future::join_all;
 use k8s_openapi::api::core::v1::{ConfigMap, Event, Node, Pod, Secret};
 use kube::api::ListParams;
-use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::config::Kubeconfig;
 use kube::core::discovery::verbs::{LIST, WATCH};
 use kube::core::ApiResource;
 use kube::{discovery, Api, Client, ResourceExt};

--- a/src/gather/writer.rs
+++ b/src/gather/writer.rs
@@ -252,7 +252,7 @@ impl Writer {
                 let file_path = archive.0.join(archive_path);
 
                 // generate diff and write
-                let original = Reader::new(archive.clone(), Utc::now())?.read(file_path.clone())?;
+                let original = Reader::new(archive.clone().into(), Utc::now())?.read(file_path.clone())?;
                 let updated = serde_yaml::from_str(repr.data())?;
                 let patch = &diff(&original, &updated);
                 if !patch.deref().is_empty() {


### PR DESCRIPTION
getting list of ressources is working fine using kubectl or k9s but not using other cli like flux one :

```
flux get helmreleases
✗ no kind "HelmreleaseList" is registered for version "v1" in scheme "pkg/runtime/scheme.go:110"
```

The reason is that the API is returning:
```yaml
apiVersion: v1
kind: HelmreleaseList
items: []
kind: List
```

But it should be
```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmReleaseList
items: []
kind: List
```

I just injected the group/version in apiVersion at a first step, but there is a subtle detail, list kind must be using PascalCase. There are no way to deduct the PascalCase name of a resource based on his only plural lowercase name.


This PR fix this, parsing the `apis.json` and `api.json` files to get the required names.

I introduced
- an `ArchiveReader` struct which contains the (manually) deserialized part we need from these files as HashMap<GroupVersionResource, NamedResource>.
- an NamedObject which is used in place of Get and List

I kept the former behavior as default if no gvr is found in the `ArchiveReader`

The singular method benefits from this PR also as the information is collected as the PascalCase kind.