### PR TITLE
Enable http-proxy feature for kube client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-kube = { version = "3.1.0", features = ["socks5", "ws", "aws-lc-rs"] }
+kube = { version = "3.1.0", features = ["socks5", "ws", "aws-lc-rs", "http-proxy"] }
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 tokio = { version = "1.51.0", features = ["rt-multi-thread"], default-features = false}
 serde_yaml = "0.9.28"


### PR DESCRIPTION
Enable the `http-proxy` feature on the `kube` dependency so crust-gather works in environments with HTTP proxies configured.

Currently, when a kubeconfig or environment has an HTTP proxy set (e.g., `HTTP_PROXY` / `HTTPS_PROXY`), crust-gather fails with:

```
Error: configured proxy http://vpn-proxy.vpn-proxy.svc:3128/ requires the disabled feature "kube/http-proxy"
```