### PR TITLE
Improve default table output with CEL based printer columns logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "antlr4rust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093d520274bfff7278d776f7ea12981a0a0a6f96db90964658e0f38fc6e9a6a6"
+dependencies = [
+ "better_any",
+ "bit-set",
+ "byteorder",
+ "lazy_static",
+ "murmur3",
+ "once_cell",
+ "parking_lot",
+ "typed-arena",
+ "uuid",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "better_any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +554,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -703,6 +741,22 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cel"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a40f338a8c3505921000b609279775792c07cc21f97a3011578c0c5e1738ae"
+dependencies = [
+ "antlr4rust",
+ "chrono",
+ "lazy_static",
+ "nom",
+ "pastey",
+ "regex",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -966,6 +1020,7 @@ dependencies = [
  "base64",
  "build_html",
  "cached",
+ "cel",
  "chrono",
  "clap",
  "duration-string",
@@ -980,6 +1035,7 @@ dependencies = [
  "jsonptr",
  "k8s-openapi",
  "kube",
+ "kube-cel",
  "logos",
  "oci-client",
  "pin-project",
@@ -2207,6 +2263,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube-cel"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ac02b78d78e251630ddd6136a0c9fa190239a01b76f8944d5bf6b3ce35128a"
+dependencies = [
+ "base64",
+ "cel",
+ "ipnet",
+ "regex",
+ "semver",
+ "url",
+]
+
+[[package]]
 name = "kube-client"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2531,15 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "murmur3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4176,6 +4255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4364,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ tempfile = "3.27.0"
 backon = "1.6.0"
 indicatif = "0.18.4"
 pin-project = "1.1.11"
+cel = "0.13.0"
+kube-cel = { version = "0.5.3", features = ["strings", "lists", "format"] }
 
 [dev-dependencies]
 xid = "1.1.1"

--- a/src/gather/mod.rs
+++ b/src/gather/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod printers;
 pub mod reader;
 pub mod representation;
 pub mod selector;

--- a/src/gather/printers.rs
+++ b/src/gather/printers.rs
@@ -1,0 +1,730 @@
+use std::{collections::BTreeMap, sync::OnceLock};
+
+use cel::{
+    Context, FunctionContext, Program, Value,
+    extractors::This,
+    objects::{Key, KeyRef},
+};
+use chrono::Utc;
+use k8s_openapi::{
+    apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceColumnDefinition,
+    apimachinery::pkg::apis::meta::v1::LabelSelector,
+    serde_json::{self, json},
+};
+use kube::core::Selector;
+use kube_cel::register_all;
+use serde_json_path::JsonPath;
+
+static PREDEFINED_TABLES: OnceLock<BTreeMap<String, Vec<ColumnDefinition>>> = OnceLock::new();
+pub const AGE_CEL: &str = "(now - timestamp(self.metadata.creationTimestamp)).age()";
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct TablePath {
+    pub column: ColumnDefinition,
+    pub json_path: Option<JsonPath>,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct ColumnDefinition {
+    pub source: CustomResourceColumnDefinition,
+    pub cel: Option<String>,
+}
+
+impl ColumnDefinition {
+    pub fn json(name: &str, json_path: &str) -> Self {
+        Self {
+            source: CustomResourceColumnDefinition {
+                name: name.into(),
+                json_path: json_path.into(),
+                ..Default::default()
+            },
+            cel: None,
+        }
+    }
+
+    pub fn cel(name: &str, cel: impl Into<String>) -> Self {
+        Self {
+            source: CustomResourceColumnDefinition {
+                name: name.into(),
+                ..Default::default()
+            },
+            cel: Some(cel.into()),
+        }
+    }
+}
+
+pub fn predefined_table(resource: &str) -> Option<Vec<TablePath>> {
+    let columns = predefined_tables().get(resource)?;
+    Some(columns.iter().map(TablePath::new).collect())
+}
+
+pub fn has_predefined_table(resource: &str) -> bool {
+    predefined_tables().contains_key(resource)
+}
+
+fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
+    PREDEFINED_TABLES.get_or_init(|| {
+        let mut map = BTreeMap::new();
+        map.insert(
+            "events".into(),
+            vec![
+                ColumnDefinition::cel("lastTimestamp", "(now - timestamp(self.lastTimestamp)).age()"),
+                ColumnDefinition::json("type", ".type"),
+                ColumnDefinition::json("reason", ".reason"),
+                ColumnDefinition::json("object", ".metadata.name"),
+                ColumnDefinition::json("message", ".message"),
+            ],
+        );
+        map.insert(
+            "pods".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel(
+                    "Ready",
+                        r#""%s/%s".format([
+                            self.get("status").get("containerStatuses").or([])
+                                .filter(status, status.ready)
+                                .size(),
+                            self.get("status").get("containerStatuses").or(
+                                self.get("spec").get("containers").or([]))
+                                .size()
+                            ])"#
+                ),
+                ColumnDefinition::cel(
+                    "Status",
+                        r#"has(self.metadata.deletionTimestamp)
+                            ? 'Terminating'
+                            : self.get("status").get("reason").or("") != "" ? self.get("status").get("reason") : self.get("status").get("phase").or("").string()"#
+                ),
+                ColumnDefinition::cel(
+                    "Restarts",
+                        r#"self.get("status").get("initContainerStatuses").or([]).map(status, status.get("restartCount").or(0).int()).sum()
+                            +
+                            self.get("status").get("containerStatuses").or([]).map(status, status.get("restartCount").or(0).int()).sum()"#
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "namespaces".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel(
+                    "Status",
+                        r#"has(self.metadata.deletionTimestamp)
+                            ? 'Terminating'
+                            : self.get("status").get("phase").or("")"#
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "deployments".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel(
+                    "Ready",
+                        r#""%s/%s".format([
+                            self.get("status").get("readyReplicas").or(0),
+                            self.get("spec").get("replicas").or(1)
+                        ])"#,
+                ),
+                ColumnDefinition::cel("Up-to-date", r#"self.get("status").get("updatedReplicas").or(0)"#),
+                ColumnDefinition::cel("Available", r#"self.get("status").get("availableReplicas").or(0)"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "services".into(),
+            vec![
+                ColumnDefinition::json("NAME", ".metadata.name"),
+                ColumnDefinition::json("TYPE", ".spec.type"),
+                ColumnDefinition::json("CLUSTER-IP", ".spec.clusterIP"),
+                ColumnDefinition::cel(
+                    "EXTERNAL-IP",
+                        r#"
+                        self.get("status").get("loadBalancer").get("ingress").or([]).size() > 0
+                            ? self.get("status").get("loadBalancer").get("ingress")
+                                .map(ingress, ingress.get("ip").or(ingress.get("hostname")))
+                                .join(',')
+                            : (
+                                self.spec.get("externalIPs").or([]).size() > 0
+                                    ? self.spec.get("externalIPs").or([]).join(',')
+                                    : '<none>'
+                                )"#
+                ),
+                ColumnDefinition::cel(
+                    "PORT(S)",
+                        r#"has(self.spec.ports)
+                            ? self.spec.ports
+                                .map(
+                                    port,
+                                    string(port.port)
+                                    + (has(port.nodePort) ? ':' + string(port.nodePort) : '')
+                                    + '/'
+                                    + (has(port.protocol) ? port.protocol : 'TCP')
+                                )
+                                .join(',')
+                            : ''"#
+                ),
+                ColumnDefinition::cel("AGE", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "daemonsets".into(),
+            vec![
+                ColumnDefinition::json("NAME", ".metadata.name"),
+                ColumnDefinition::cel("DESIRED", r#"self.get("status").get("desiredNumberScheduled").or(0)"#),
+                ColumnDefinition::cel("CURRENT", r#"self.get("status").get("currentNumberScheduled").or(0)"#),
+                ColumnDefinition::cel("READY", r#"self.get("status").get("numberReady").or(0)"#),
+                ColumnDefinition::cel("UP-TO-DATE", r#"self.get("status").get("updatedNumberScheduled").or(0)"#),
+                ColumnDefinition::cel("AVAILABLE", r#"self.get("status").get("numberAvailable").or(0)"#),
+                ColumnDefinition::cel(
+                    "NODE SELECTOR",
+                    r#"self.spec.template.spec.get("nodeSelector").or({}).size() > 0 ? self.spec.template.spec.nodeSelector.selector() : '<none>'"#,
+                ),
+                ColumnDefinition::cel("AGE", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "configmaps".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Data", r#"self.get("data").or({}).size() + self.get("binaryData").or({}).size()"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "secrets".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::json("Type", ".type"),
+                ColumnDefinition::cel("Data", r#"self.get("data").or({}).size()"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "serviceaccounts".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "networkpolicies".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Pod-Selector", "self.spec.podSelector.labelSelector()"),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "rolebindings".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Role", "self.roleRef.kind + '/' + self.roleRef.name"),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "clusterrolebindings".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Role", "self.roleRef.kind + '/' + self.roleRef.name"),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "leases".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Holder", r#"self.get("spec").get("holderIdentity").or('')"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "mutatingwebhookconfigurations".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Webhooks", r#"self.get("webhooks").or([]).size()"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "validatingwebhookconfigurations".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Webhooks", r#"self.get("webhooks").or([]).size()"#),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "validatingadmissionpolicies".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Validations", r#"self.get("spec").get("validations").or([]).size()"#),
+                ColumnDefinition::cel(
+                    "ParamKind",
+                    r#"self.get("spec").get("paramKind").get("kind").or('') == '' ? '<unset>' : self.get("spec").get("paramKind").get("apiVersion").or('') + '/' + self.get("spec").get("paramKind").get("kind").or('')"#,
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "validatingadmissionpolicybindings".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("PolicyName", r#"self.get("spec").get("policyName").or('')"#),
+                ColumnDefinition::cel(
+                    "ParamRef",
+                        r#"self.get("spec").get("paramRef").or({}).size() == 0
+                            ? '<unset>'
+                            : (
+                                self.get("spec").get("paramRef").get("name").or('') != ''
+                                    ? (
+                                        self.get("spec").get("paramRef").get("namespace").or('') != ''
+                                            ? self.get("spec").get("paramRef").get("namespace").or('')
+                                                + '/'
+                                                + self.get("spec").get("paramRef").get("name").or('')
+                                            : '*/' + self.get("spec").get("paramRef").get("name").or('')
+                                    )
+                                    : (
+                                        self.get("spec").get("paramRef").get("selector").or({}).size() > 0
+                                            ? self.get("spec").get("paramRef").get("selector").labelSelector()
+                                            : '<unset>'
+                                    )
+                            )"#
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "mutatingadmissionpolicies".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel("Mutations", r#"self.get("spec").get("mutations").or([]).size()"#),
+                ColumnDefinition::cel(
+                    "ParamKind",
+                    r#"self.get("spec").get("paramKind").get("kind").or('') == '' ? '<unset>' : self.get("spec").get("paramKind").get("apiVersion").or('') + '/' + self.get("spec").get("paramKind").get("kind").or('')"#,
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map.insert(
+            "mutatingadmissionpolicybindings".into(),
+            vec![
+                ColumnDefinition::json("Name", ".metadata.name"),
+                ColumnDefinition::cel(
+                    "ParamRef",
+                        r#"self.get("spec").get("paramRef").or({}).size() == 0
+                            ? '<unset>'
+                            : (
+                                self.get("spec").get("paramRef").get("name").or('') != ''
+                                    ? (
+                                        self.get("spec").get("paramRef").get("namespace").or('') != ''
+                                            ? self.get("spec").get("paramRef").get("namespace").or('')
+                                                + '/'
+                                                + self.get("spec").get("paramRef").get("name").or('')
+                                            : '*/' + self.get("spec").get("paramRef").get("name").or('')
+                                    )
+                                    : (
+                                        self.get("spec").get("paramRef").get("selector").or({}).size() > 0
+                                            ? self.get("spec").get("paramRef").get("selector").labelSelector()
+                                            : '<unset>'
+                                    )
+                            )"#
+                ),
+                ColumnDefinition::cel("Age", AGE_CEL),
+            ],
+        );
+        map
+    })
+}
+
+impl TablePath {
+    pub fn new(column: &ColumnDefinition) -> Self {
+        let json_path = if column.cel.is_some() || column.source.json_path.is_empty() {
+            None
+        } else {
+            let json_path = format!("${}", column.source.json_path.replace(r"\.", "."));
+            match JsonPath::parse(&json_path) {
+                Ok(json_path) => Some(json_path),
+                Err(e) => {
+                    tracing::debug!("unable to parse json path for {json_path}: {e:?}");
+                    None
+                }
+            }
+        };
+        Self {
+            column: column.clone(),
+            json_path,
+        }
+    }
+
+    pub fn to_definition(&self) -> serde_json::Value {
+        let mut definition = serde_json::Map::from_iter([
+            ("name".into(), json!(self.column.source.name)),
+            (
+                "format".into(),
+                json!(self.column.source.format.clone().unwrap_or_default()),
+            ),
+            (
+                "description".into(),
+                json!(self.column.source.description.clone().unwrap_or_default()),
+            ),
+            (
+                "priority".into(),
+                json!(self.column.source.priority.unwrap_or_default()),
+            ),
+        ]);
+        if !self.column.source.type_.is_empty() {
+            definition.insert("type".into(), json!(self.column.source.type_));
+        }
+
+        serde_json::Value::Object(definition)
+    }
+
+    pub fn render(&self, obj: &serde_json::Value) -> Option<serde_json::Value> {
+        let Some(cel) = &self.column.cel else {
+            return self
+                .json_path
+                .as_ref()
+                .and_then(|json_path| json_path.query(obj).first().cloned());
+        };
+
+        let program = Program::compile(cel).unwrap();
+        let mut context = Context::default();
+
+        register_all(&mut context);
+
+        context.add_function("selector", Self::cel_selector_string);
+        context.add_function("labelSelector", Self::cel_label_selector_string);
+        context.add_function("get", Self::cel_get);
+        context.add_function("or", Self::cel_or);
+        context.add_function("age", Self::cel_age);
+
+        context.add_variable("self", obj).ok()?;
+        context
+            .add_variable("now", Value::Timestamp(Utc::now().fixed_offset()))
+            .ok()?;
+
+        let value = match program.execute(&context) {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::error!(
+                    "failed to execute CEL for column {}: {cel}: {error}",
+                    self.column.source.name
+                );
+
+                return None;
+            }
+        };
+
+        Self::cel_value_to_json(value)
+    }
+
+    fn cel_value_to_json(value: Value) -> Option<serde_json::Value> {
+        match value {
+            Value::Map(map) => {
+                let mut json = serde_json::Map::new();
+                for (key, value) in map.map.iter() {
+                    let Key::String(key) = key else {
+                        return None;
+                    };
+
+                    json.insert(key.to_string(), Self::cel_value_to_json(value.clone())?);
+                }
+
+                Some(serde_json::Value::Object(json))
+            }
+            Value::List(values) => values
+                .iter()
+                .cloned()
+                .map(Self::cel_value_to_json)
+                .collect::<Option<Vec<_>>>()
+                .map(serde_json::Value::Array),
+            Value::Int(value) => Some(json!(value)),
+            Value::UInt(value) => Some(json!(value)),
+            Value::Float(value) => Some(json!(value)),
+            Value::String(value) => Some(json!(value)),
+            Value::Bool(value) => Some(json!(value)),
+            Value::Timestamp(value) => Some(json!(value.to_rfc3339())),
+            Value::Duration(value) => Some(json!(value.num_seconds())),
+            Value::Null => Some(serde_json::Value::Null),
+            _ => None,
+        }
+    }
+
+    fn cel_selector_string(
+        ftx: &FunctionContext,
+        This(this): This<Value>,
+    ) -> Result<Value, cel::ExecutionError> {
+        let Value::Map(map) = this else {
+            return Err(ftx.error(format!(
+                "cannot format selector from non-map value: {this:?}"
+            )));
+        };
+
+        let mut labels = BTreeMap::new();
+        for (key, value) in map.map.iter() {
+            let Key::String(key) = key else {
+                return Err(ftx.error(format!(
+                    "cannot format selector from non-string key: {key:?}"
+                )));
+            };
+            let Value::String(value) = value else {
+                return Err(ftx.error(format!(
+                    "cannot format selector from non-string value for key {key}: {value:?}"
+                )));
+            };
+
+            labels.insert(key.to_string(), value.to_string());
+        }
+
+        Ok(Value::String(
+            Selector::from_iter(labels).to_string().into(),
+        ))
+    }
+
+    fn cel_label_selector_string(
+        ftx: &FunctionContext,
+        This(this): This<Value>,
+    ) -> Result<Value, cel::ExecutionError> {
+        let Value::Map(_) = &this else {
+            return Err(ftx.error(format!(
+                "cannot format label selector from non-map value: {this:?}"
+            )));
+        };
+
+        let json = Self::cel_value_to_json(this).ok_or_else(|| {
+            ftx.error("cannot convert label selector to json-compatible object".to_string())
+        })?;
+        let selector: LabelSelector = serde_json::from_value(json)
+            .map_err(|error| ftx.error(format!("cannot parse label selector: {error}")))?;
+        let selector = Selector::try_from(selector)
+            .map_err(|error| ftx.error(format!("cannot format label selector: {error}")))?;
+        let selector = selector.to_string();
+
+        Ok(Value::String(
+            if selector.is_empty() {
+                "<none>"
+            } else {
+                &selector
+            }
+            .to_string()
+            .into(),
+        ))
+    }
+
+    fn cel_age(
+        ftx: &FunctionContext,
+        This(this): This<Value>,
+    ) -> Result<Value, cel::ExecutionError> {
+        let Value::Duration(duration) = this else {
+            return Err(ftx.error(format!("cannot format age from {this:?}")));
+        };
+
+        Ok(Value::String(Self::format_age(duration).into()))
+    }
+
+    fn cel_or(This(this): This<Value>, default: Value) -> Result<Value, cel::ExecutionError> {
+        match this {
+            Value::Null | Value::Bool(false) => Ok(default),
+            value => Ok(value),
+        }
+    }
+
+    fn cel_get(This(this): This<Value>, key: Value) -> Result<Value, cel::ExecutionError> {
+        let Value::Map(map) = this else {
+            return Ok(Value::Null);
+        };
+
+        let Ok(key) = KeyRef::try_from(&key) else {
+            return Ok(Value::Null);
+        };
+
+        Ok(map.get(&key).cloned().unwrap_or(Value::Null))
+    }
+
+    fn format_age(duration: chrono::Duration) -> String {
+        let seconds = duration.num_seconds().max(0);
+        if seconds < 60 {
+            format!("{seconds}s")
+        } else {
+            let minutes = seconds / 60;
+            if minutes < 60 {
+                format!("{minutes}m")
+            } else {
+                let hours = minutes / 60;
+                if hours < 24 {
+                    format!("{hours}h")
+                } else {
+                    let days = hours / 24;
+                    let hours = hours % 24;
+                    if hours > 0 {
+                        format!("{days}d{hours}h")
+                    } else {
+                        format!("{days}d")
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cel::{Context, Program, Value};
+    use serde_json::json;
+
+    use super::TablePath;
+
+    fn render_selector(
+        value: serde_json::Value,
+    ) -> Result<Option<serde_json::Value>, cel::ExecutionError> {
+        let program = Program::compile("self.selector()").unwrap();
+        let mut context = Context::default();
+        context.add_function("selector", TablePath::cel_selector_string);
+        context.add_variable("self", value).unwrap();
+        let value = program.execute(&context)?;
+        Ok(TablePath::cel_value_to_json(value))
+    }
+
+    fn render_label_selector(
+        value: serde_json::Value,
+    ) -> Result<Option<serde_json::Value>, cel::ExecutionError> {
+        let program = Program::compile("self.labelSelector()").unwrap();
+        let mut context = Context::default();
+        context.add_function("labelSelector", TablePath::cel_label_selector_string);
+        context.add_variable("self", value).unwrap();
+        let value = program.execute(&context)?;
+        Ok(TablePath::cel_value_to_json(value))
+    }
+
+    fn evaluate(expr: &str, self_value: serde_json::Value, default: serde_json::Value) -> Value {
+        let program = Program::compile(expr).unwrap();
+        let mut context = Context::default();
+        context.add_function("get", TablePath::cel_get);
+        context.add_function("or", TablePath::cel_or);
+        context.add_variable("self", self_value).unwrap();
+        context.add_variable("default", default).unwrap();
+        program.execute(&context).unwrap()
+    }
+
+    #[test]
+    fn selector_string_formats_match_labels() {
+        assert_eq!(
+            Some(json!("app=api,tier=backend")),
+            render_selector(json!({
+                "app": "api",
+                "tier": "backend",
+            }))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn selector_string_returns_error_for_non_string_values() {
+        assert!(
+            render_selector(json!({
+                "app": 1,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn selector_string_returns_error_for_non_map_values() {
+        assert!(render_selector(json!("app=api")).is_err());
+    }
+
+    #[test]
+    fn label_selector_string_formats_match_labels_and_expressions() {
+        assert_eq!(
+            Some(json!("app=api,tier in (backend,worker)")),
+            render_label_selector(json!({
+                "matchLabels": {
+                    "app": "api"
+                },
+                "matchExpressions": [
+                    {
+                        "key": "tier",
+                        "operator": "In",
+                        "values": ["backend", "worker"]
+                    }
+                ]
+            }))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn label_selector_string_returns_none_marker_for_empty_selector() {
+        assert_eq!(
+            Some(json!("<none>")),
+            render_label_selector(json!({})).unwrap()
+        );
+    }
+
+    #[test]
+    fn or_returns_default_for_null() {
+        assert_eq!(
+            Value::Int(3.into()),
+            evaluate(
+                "self.or(default).size()",
+                serde_json::Value::Null,
+                json!([1, 2, 3])
+            )
+        );
+    }
+
+    #[test]
+    fn or_returns_default_for_false() {
+        assert_eq!(
+            Value::String(Arc::new(String::from("fallback"))),
+            evaluate("self.or(default)", json!(false), json!("fallback"))
+        );
+    }
+
+    #[test]
+    fn or_keeps_truthy_values() {
+        assert_eq!(
+            Value::Int(2.into()),
+            evaluate("self.or(default).size()", json!([1, 2]), json!([]))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            evaluate("self.or(default)", json!(true), json!(false))
+        );
+        assert_eq!(
+            Value::Int(0.into()),
+            evaluate("self.or(default)", json!(0), json!(42))
+        );
+    }
+
+    #[test]
+    fn get_returns_nested_value_when_present() {
+        assert_eq!(
+            Value::Int(3.into()),
+            evaluate(
+                r#"self.get("status").get("restartCount").or(default)"#,
+                json!({"status": {"restartCount": 3}}),
+                json!(0),
+            )
+        );
+    }
+
+    #[test]
+    fn get_returns_null_for_missing_paths() {
+        assert_eq!(
+            Value::Int(0.into()),
+            evaluate(
+                r#"self.get("status").get("restartCount").or(default)"#,
+                json!({}),
+                json!(0),
+            )
+        );
+    }
+}

--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     hash::Hash,
     io::{self, BufRead as _},
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -37,6 +37,7 @@ use crate::{
 };
 
 use super::{
+    printers::{AGE_CEL, ColumnDefinition, TablePath, has_predefined_table, predefined_table},
     representation::{
         ArchivePath, Container, LogGroup, NamespaceName, NamespacedName, TypeMetaGetter,
     },
@@ -47,46 +48,6 @@ use super::{
 const ADDED_PATH: [&str; 3] = ["metadata", "annotations", ADDED_ANNOTATION];
 const UPDATED_PATH: [&str; 3] = ["metadata", "annotations", UPDATED_ANNOTATION];
 const DELETED_PATH: [&str; 3] = ["metadata", "annotations", DELETED_ANNOTATION];
-
-static PREDEFINED_TABLES: OnceLock<BTreeMap<String, Vec<CustomResourceColumnDefinition>>> =
-    OnceLock::new();
-
-fn predefined_tables() -> &'static BTreeMap<String, Vec<CustomResourceColumnDefinition>> {
-    PREDEFINED_TABLES.get_or_init(|| {
-        let mut map = BTreeMap::new();
-        map.insert(
-            "events".into(),
-            vec![
-                CustomResourceColumnDefinition {
-                    name: "lastTimestamp".into(),
-                    json_path: ".lastTimestamp".into(),
-                    ..Default::default()
-                },
-                CustomResourceColumnDefinition {
-                    name: "type".into(),
-                    json_path: ".type".into(),
-                    ..Default::default()
-                },
-                CustomResourceColumnDefinition {
-                    name: "reason".into(),
-                    json_path: ".reason".into(),
-                    ..Default::default()
-                },
-                CustomResourceColumnDefinition {
-                    name: "object".into(),
-                    json_path: ".metadata.name".into(),
-                    ..Default::default()
-                },
-                CustomResourceColumnDefinition {
-                    name: "message".into(),
-                    json_path: ".message".into(),
-                    ..Default::default()
-                },
-            ],
-        );
-        map
-    })
-}
 
 #[derive(Deserialize, Clone)]
 pub struct Destination {
@@ -171,39 +132,6 @@ pub struct Table {
     pub items: Vec<serde_json::Value>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct TablePath {
-    pub column: CustomResourceColumnDefinition,
-    pub json_path: Option<JsonPath>,
-}
-
-impl TablePath {
-    fn new(column: &CustomResourceColumnDefinition) -> Self {
-        let json_path = format!("${}", column.json_path.replace(r"\.", r"."));
-        let json_path = match JsonPath::parse(&json_path) {
-            Ok(json_path) => Some(json_path),
-            Err(e) => {
-                tracing::debug!("unable to parse json path for {json_path}: {e:?}");
-                None
-            }
-        };
-        Self {
-            column: column.clone(),
-            json_path,
-        }
-    }
-
-    fn to_definition(&self) -> serde_json::Value {
-        json!({
-            "name": self.column.name,
-            "type": self.column.type_,
-            "format": self.column.format.clone().unwrap_or_default(),
-            "description": self.column.description.clone().unwrap_or_default(),
-            "priority": self.column.priority.unwrap_or_default(),
-        })
-    }
-}
-
 impl Table {
     async fn new(
         crd_path: PathBuf,
@@ -235,12 +163,17 @@ impl Table {
                 storage.read(crd_path, &mut file).await?;
                 serde_yaml::from_slice(&file)?
             }
-            false => match predefined_tables().get(&list.named_resource.resource) {
+            false => match predefined_table(&list.named_resource.resource) {
                 Some(columns) => CustomResourceDefinition {
                     spec: CustomResourceDefinitionSpec {
                         versions: vec![CustomResourceDefinitionVersion {
                             name: list.named_resource.version.clone(),
-                            additional_printer_columns: Some(columns.clone()),
+                            additional_printer_columns: Some(
+                                columns
+                                    .iter()
+                                    .map(|entry| entry.column.source.clone())
+                                    .collect(),
+                            ),
                             ..Default::default()
                         }],
                         ..Default::default()
@@ -257,43 +190,60 @@ impl Table {
             .iter()
             .find(|crd| crd.name == list.named_resource.version);
 
-        let table_entries = crd_version
+        let table_entries: Vec<TablePath> = crd_version
             .map(|version| version.additional_printer_columns.clone())
             .unwrap_or_default()
-            .map(|columns| columns.iter().map(TablePath::new).collect())
+            .map(|columns| {
+                columns
+                    .iter()
+                    .map(|column| {
+                        TablePath::new(&ColumnDefinition {
+                            source: column.clone(),
+                            ..Default::default()
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
-        Ok(
-            match predefined_tables().get(&list.named_resource.resource) {
-                Some(_) => table_entries,
-                None => {
-                    let mut data = vec![TablePath {
-                        column: CustomResourceColumnDefinition {
-                            name: "Name".to_string(),
-                            type_: "string".to_string(),
+        Ok(match has_predefined_table(&list.named_resource.resource) {
+            true => predefined_table(&list.named_resource.resource).unwrap_or_default(),
+            false => {
+                let mut data = vec![
+                    TablePath {
+                        column: ColumnDefinition {
+                            source: CustomResourceColumnDefinition {
+                                name: "Name".to_string(),
+                                type_: "string".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         json_path: JsonPath::parse("$.metadata.name").ok(),
-                    }];
-                    data.extend(table_entries);
-                    data
-                }
-            },
-        )
+                    },
+                ];
+                data.extend(
+                    table_entries
+                        .into_iter()
+                        .filter(|entry| !entry.column.source.name.eq_ignore_ascii_case("age")),
+                );
+                data.push(TablePath::new(&ColumnDefinition {
+                    source: CustomResourceColumnDefinition {
+                        name: "Age".to_string(),
+                        type_: "string".to_string(),
+                        ..Default::default()
+                    },
+                    cel: Some(AGE_CEL.to_string()),
+                }));
+                data
+            }
+        })
     }
 
     fn to_row(&self, obj: impl Serialize) -> anyhow::Result<serde_json::Value> {
         let Table { data: rows, .. } = self;
         let obj = serde_json::to_value(obj)?;
-        let cells: Vec<&serde_json::Value> = rows
-            .iter()
-            .filter_map(|r| {
-                r.json_path
-                    .as_ref()
-                    .map(|json_path| json_path.query(&obj).first())
-                    .unwrap_or_default()
-            })
-            .collect();
+        let cells: Vec<serde_json::Value> = rows.iter().filter_map(|r| r.render(&obj)).collect();
 
         Ok(json!({
             "cells": cells,
@@ -1017,6 +967,8 @@ impl Reader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
+    use serde_json::json;
 
     #[tokio::test]
     async fn table_columns() {
@@ -1040,14 +992,32 @@ mod tests {
         )
         .await;
 
-        let expected_paths = vec![TablePath {
-            column: CustomResourceColumnDefinition {
-                name: "Name".to_string(),
-                type_: "string".to_string(),
-                ..Default::default()
+        let expected_paths = vec![
+            TablePath {
+                column: ColumnDefinition {
+                    source: CustomResourceColumnDefinition {
+                        name: "Name".to_string(),
+                        type_: "string".to_string(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                json_path: JsonPath::parse("$.metadata.name").ok(),
             },
-            json_path: JsonPath::parse("$.metadata.name").ok(),
-        }];
+            TablePath {
+                column: ColumnDefinition {
+                    source: CustomResourceColumnDefinition {
+                        name: "Age".to_string(),
+                        type_: "string".to_string(),
+                        ..Default::default()
+                    },
+                    cel: Some(
+                        "(now - timestamp(self.metadata.creationTimestamp)).age()".to_string(),
+                    ),
+                },
+                json_path: None,
+            },
+        ];
 
         assert_eq!(expected_paths, tbl.unwrap().data);
     }
@@ -1074,15 +1044,436 @@ mod tests {
         )
         .await;
 
-        let expected_paths = vec![TablePath {
-            column: CustomResourceColumnDefinition {
-                name: "Name".to_string(),
-                type_: "string".to_string(),
-                ..Default::default()
+        let expected_paths = vec![
+            TablePath {
+                column: ColumnDefinition {
+                    source: CustomResourceColumnDefinition {
+                        name: "Name".to_string(),
+                        type_: "string".to_string(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                json_path: JsonPath::parse("$.metadata.name").ok(),
             },
-            json_path: JsonPath::parse("$.metadata.name").ok(),
-        }];
+            TablePath {
+                column: ColumnDefinition {
+                    source: CustomResourceColumnDefinition {
+                        name: "Age".to_string(),
+                        type_: "string".to_string(),
+                        ..Default::default()
+                    },
+                    cel: Some(
+                        "(now - timestamp(self.metadata.creationTimestamp)).age()".to_string(),
+                    ),
+                },
+                json_path: None,
+            },
+        ];
 
         assert_eq!(expected_paths, tbl.unwrap().data);
+    }
+
+    #[tokio::test]
+    async fn table_columns_pods() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: None,
+                version: "v1".to_string(),
+                resource: "pods".to_string(),
+                singular: "pod".to_string(),
+                list_kind: "PodList".to_string(),
+            },
+            namespace: Some("my-namespace".to_string()),
+            name: None,
+        };
+        let created = (Utc::now() - Duration::minutes(5)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "pod-a",
+                "namespace": "my-namespace",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "containers": [
+                    {"name": "c1"},
+                    {"name": "c2"}
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "containerStatuses": [
+                    {"ready": true, "restartCount": 1},
+                    {"ready": false, "restartCount": 2}
+                ],
+                "initContainerStatuses": [
+                    {"restartCount": 3}
+                ]
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(columns, vec!["Name", "Ready", "Status", "Restarts", "Age"]);
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("pod-a"));
+        assert_eq!(cells[1], json!("1/2"));
+        assert_eq!(cells[2], json!("Running"));
+        assert_eq!(cells[3], json!(6));
+        assert_eq!(cells[4], json!("5m"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_pods_without_status() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: None,
+                version: "v1".to_string(),
+                resource: "pods".to_string(),
+                singular: "pod".to_string(),
+                list_kind: "PodList".to_string(),
+            },
+            namespace: Some("my-namespace".to_string()),
+            name: None,
+        };
+        let created = (Utc::now() - Duration::minutes(5)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "pod-b",
+                "namespace": "my-namespace",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "containers": [
+                    {"name": "c1"}
+                ]
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("pod-b"));
+        assert_eq!(cells[1], json!("0/1"));
+        assert_eq!(cells[2], json!(""));
+        assert_eq!(cells[3], json!(0));
+        assert_eq!(cells[4], json!("5m"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_namespaces() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: None,
+                version: "v1".to_string(),
+                resource: "namespaces".to_string(),
+                singular: "namespace".to_string(),
+                list_kind: "NamespaceList".to_string(),
+            },
+            namespace: None,
+            name: None,
+        };
+        let created = (Utc::now() - Duration::hours(2)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "ns-a",
+                "creationTimestamp": created,
+                "deletionTimestamp": Utc::now().to_rfc3339(),
+            },
+            "status": {
+                "phase": "Active"
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(columns, vec!["Name", "Status", "Age"]);
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("ns-a"));
+        assert_eq!(cells[1], json!("Terminating"));
+        assert_eq!(cells[2], json!("2h"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_deployments() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: Some("apps".to_string()),
+                version: "v1".to_string(),
+                resource: "deployments".to_string(),
+                singular: "deployment".to_string(),
+                list_kind: "DeploymentList".to_string(),
+            },
+            namespace: Some("my-namespace".to_string()),
+            name: None,
+        };
+        let created = (Utc::now() - Duration::days(3)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "deploy-a",
+                "namespace": "my-namespace",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "replicas": 3
+            },
+            "status": {
+                "readyReplicas": 2,
+                "updatedReplicas": 3,
+                "availableReplicas": 2
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(
+            columns,
+            vec!["Name", "Ready", "Up-to-date", "Available", "Age"]
+        );
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("deploy-a"));
+        assert_eq!(cells[1], json!("2/3"));
+        assert_eq!(cells[2], json!(3));
+        assert_eq!(cells[3], json!(2));
+        assert_eq!(cells[4], json!("3d"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_services() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: None,
+                version: "v1".to_string(),
+                resource: "services".to_string(),
+                singular: "service".to_string(),
+                list_kind: "ServiceList".to_string(),
+            },
+            namespace: Some("default".to_string()),
+            name: None,
+        };
+        let created = (Utc::now() - Duration::days(5) - Duration::hours(9)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "kubernetes",
+                "namespace": "default",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "clusterIP": "10.96.0.1",
+                "ports": [
+                    {"port": 443, "protocol": "TCP"}
+                ]
+            },
+            "status": {}
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(
+            columns,
+            vec![
+                "NAME",
+                "TYPE",
+                "CLUSTER-IP",
+                "EXTERNAL-IP",
+                "PORT(S)",
+                "AGE"
+            ]
+        );
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("kubernetes"));
+        assert_eq!(cells[1], json!("ClusterIP"));
+        assert_eq!(cells[2], json!("10.96.0.1"));
+        assert_eq!(cells[3], json!("<none>"));
+        assert_eq!(cells[4], json!("443/TCP"));
+        assert_eq!(cells[5], json!("5d9h"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_daemonsets() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: Some("apps".to_string()),
+                version: "v1".to_string(),
+                resource: "daemonsets".to_string(),
+                singular: "daemonset".to_string(),
+                list_kind: "DaemonSetList".to_string(),
+            },
+            namespace: Some("kube-system".to_string()),
+            name: None,
+        };
+        let created = (Utc::now() - Duration::days(10)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "node-local-dns",
+                "namespace": "kube-system",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": {
+                            "kubernetes.io/os": "linux"
+                        }
+                    }
+                }
+            },
+            "status": {
+                "desiredNumberScheduled": 3,
+                "currentNumberScheduled": 3,
+                "numberReady": 3,
+                "updatedNumberScheduled": 3,
+                "numberAvailable": 3
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(
+            columns,
+            vec![
+                "NAME",
+                "DESIRED",
+                "CURRENT",
+                "READY",
+                "UP-TO-DATE",
+                "AVAILABLE",
+                "NODE SELECTOR",
+                "AGE"
+            ]
+        );
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("node-local-dns"));
+        assert_eq!(cells[1], json!(3));
+        assert_eq!(cells[2], json!(3));
+        assert_eq!(cells[3], json!(3));
+        assert_eq!(cells[4], json!(3));
+        assert_eq!(cells[5], json!(3));
+        assert_eq!(cells[6], json!("kubernetes.io/os=linux"));
+        assert_eq!(cells[7], json!("10d"));
+    }
+
+    #[tokio::test]
+    async fn table_columns_validating_admission_policy_bindings() {
+        let list = NamedObject {
+            named_resource: NamedResource {
+                group: Some("admissionregistration.k8s.io".to_string()),
+                version: "v1".to_string(),
+                resource: "validatingadmissionpolicybindings".to_string(),
+                singular: "validatingadmissionpolicybinding".to_string(),
+                list_kind: "ValidatingAdmissionPolicyBindingList".to_string(),
+            },
+            namespace: None,
+            name: None,
+        };
+        let created = (Utc::now() - Duration::minutes(15)).to_rfc3339();
+        let items = vec![json!({
+            "metadata": {
+                "name": "binding-a",
+                "creationTimestamp": created,
+            },
+            "spec": {
+                "policyName": "require-team-label",
+                "paramRef": {
+                    "namespace": "default",
+                    "name": "team-label-params"
+                }
+            }
+        })];
+        let tbl = Table::new(
+            PathBuf::from("hello".to_string()),
+            list,
+            items,
+            &Storage::FS,
+        )
+        .await
+        .unwrap();
+
+        let columns: Vec<&str> = tbl
+            .data
+            .iter()
+            .map(|entry| entry.column.source.name.as_str())
+            .collect();
+        assert_eq!(columns, vec!["Name", "PolicyName", "ParamRef", "Age"]);
+
+        let row = tbl.to_row(&tbl.items[0]).unwrap();
+        let cells = row["cells"].as_array().unwrap();
+        assert_eq!(cells[0], json!("binding-a"));
+        assert_eq!(cells[1], json!("require-team-label"));
+        assert_eq!(cells[2], json!("default/team-label-params"));
+        assert_eq!(cells[3], json!("15m"));
     }
 }


### PR DESCRIPTION
When trying `kubectl ai` with a crust-gather archive, local models were often confused by different output format for tables. Since these models are rather weak, the less context they will process, the better chance of it working.

This change starts improvements of table column printing logic, by replicating what https://github.com/kubernetes/kubernetes/blob/v1.35.3/pkg/printers/internalversion/printers.go is doing, but in CEL