### PR TITLE
Fix cross-archive cache collision when serving multiple snapshots

### DIFF
--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -577,6 +577,11 @@ impl ArchiveReader {
         self.archive.join(path)
     }
 
+    /// Returns the archive's root path. Used to distinguish archives in hash/eq.
+    pub fn path(&self) -> PathBuf {
+        self.archive.path()
+    }
+
     pub fn named_object_from_list(&self, list: List) -> NamedObject {
         let gvr = GroupVersionResource::gvr(
             &list.group.clone().unwrap_or_default(),
@@ -626,12 +631,20 @@ pub struct Reader {
 }
 
 impl Hash for Reader {
-    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    // Hash on the archive's path so that readers for different archives produce
+    // different cache keys in `#[cached]` functions. Previously this was a no-op,
+    // which made all Readers collide in the cache: the first archive's response
+    // for a given path/list/get would be returned for every other archive too.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.archive.path().hash(state);
+    }
 }
 
 impl PartialEq for Reader {
-    fn eq(&self, _: &Self) -> bool {
-        true
+    // Equal iff the underlying archive paths match. See `Hash` above for the
+    // rationale; both must agree for the cache to correctly distinguish archives.
+    fn eq(&self, other: &Self) -> bool {
+        self.archive.path() == other.archive.path()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #444.

`Reader` implemented `Hash` as a no-op and `PartialEq` to always return `true`, which made every `Reader` instance indistinguishable in the cache keys produced by the `#[cached(result)]` macros on `load_raw`, `load`, `load_list`, `load_table`, and the watch helpers in `server.rs`.

When `crust-gather serve --archive <dir>` is pointed at a directory containing multiple snapshots, the server wraps each in its own `ArchiveReader` / `Reader`. With the broken `Hash`/`Eq`, the first archive to be queried for a given `(path, list, get, selector)` would populate the cache with its result, and subsequent queries against other archives received that same result — even though they referenced different data. This manifested as API groups from one snapshot leaking into another's discovery response, and eventually as missing resource types when the affected snapshot's groups were masked by another's.

`Hash`/`Eq` are now derived from the archive's root path, so distinct archives produce distinct cache keys while repeated queries against the same archive still hit the cache.

Added an `ArchiveReader::path` accessor to expose the underlying `Archive` path for this purpose.

## Test plan

Reproduced with two snapshots from different clusters (one with ~100 API groups, one with ~39) placed side-by-side under `./snapshots/mc` and `./snapshots/wc`.

Before the fix:
- Initial `curl /mc/apis` returned 100 groups; `/wc/apis` returned 39.
- After a few `kubectl` queries alternating between `--context mc` and `--context wc`, `/mc/apis` started returning 39 groups (WC's set), and `kubectl --context mc get helmreleases -A` began returning `"the server doesn't have a resource type helmreleases"`.

After the fix, repeated stress-testing with alternating context queries:

```
for i in $(seq 1 10); do
  kubectl --context mc get helmreleases -A
  kubectl --context wc get pods -A
  kubectl --context mc get apps -A
  kubectl --context wc get deployments -A
done
```

- `/mc/apis` remains at 100 groups, `/wc/apis` remains at 39.
- `kubectl --context mc get helmreleases -A` and `kubectl --context mc get apps -A` continue to return results correctly.
- `kubectl --context wc get pods -A` returns the WC's pods with full column data.

## Checklist

- [x] Built with `cargo build --release`
- [x] Verified manually with two real snapshots