### PR TITLE
Make OCI layers buffer configurable and support deprecated event fields

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,8 @@ use crate::{
     mcp_server,
 };
 
+pub const DEFAULT_OCI_BUFFER_SIZE: usize = 32;
+
 use tracing_subscriber::Layer;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt;
@@ -436,6 +438,15 @@ pub struct OCISettings {
     #[arg(short, long, value_parser = |arg: &str| -> anyhow::Result<OCIReference> {Ok(arg.try_into()?)})]
     #[serde(default)]
     pub reference: Option<OCIReference>,
+
+    /// Maximum number of OCI layers processed concurrently
+    #[arg(short, long, value_parser = |arg: &str| -> anyhow::Result<usize> {
+        let value = arg.parse::<u64>()?;
+        anyhow::ensure!(value >= 1, "buffer size must be at least 1");
+        Ok(value.try_into()?)
+    }, default_value_t = DEFAULT_OCI_BUFFER_SIZE)]
+    #[serde(default = "default_oci_buffer_size")]
+    pub buffer_size: usize,
 }
 
 #[derive(
@@ -531,6 +542,11 @@ impl OCISettings {
             insecure: self.insecure || other.insecure,
             ca_file: self.ca_file.clone().or(other.ca_file),
             reference: self.reference.clone().or(other.reference),
+            buffer_size: if self.buffer_size == DEFAULT_OCI_BUFFER_SIZE {
+                other.buffer_size
+            } else {
+                self.buffer_size
+            },
         }
     }
 
@@ -547,7 +563,7 @@ impl OCISettings {
             });
         }
 
-        config.max_concurrent_upload = 32;
+        config.max_concurrent_upload = self.buffer_size;
 
         config
     }
@@ -638,9 +654,14 @@ impl GatherSettings {
             encoding,
             client_config,
             auth,
+            self.oci.buffer_size,
         )
         .await
     }
+}
+
+const fn default_oci_buffer_size() -> usize {
+    DEFAULT_OCI_BUFFER_SIZE
 }
 
 #[derive(Parser, Clone, Default, Deserialize)]

--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -512,6 +512,7 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::{
+        cli::DEFAULT_OCI_BUFFER_SIZE,
         filters::filter::{FilterList, Include},
         gather::writer::{Archive, Encoding},
     };
@@ -593,10 +594,16 @@ mod tests {
         let config = Config {
             client,
             filter: Arc::new(FilterGroup(vec![FilterList(vec![vec![f].into()])])),
-            writer: Writer::new(&Archive::new(file_path), &Encoding::Zip, None, None)
-                .await
-                .expect("failed to create builder")
-                .into(),
+            writer: Writer::new(
+                &Archive::new(file_path),
+                &Encoding::Zip,
+                None,
+                None,
+                DEFAULT_OCI_BUFFER_SIZE,
+            )
+            .await
+            .expect("failed to create builder")
+            .into(),
             secrets: Default::default(),
             mode: GatherMode::Collect,
             duration: "10s".try_into().unwrap(),
@@ -624,10 +631,16 @@ mod tests {
         let config = Config {
             client,
             filter: Arc::new(FilterGroup(vec![FilterList(vec![])])),
-            writer: Writer::new(&Archive::new(file_path), &Encoding::Gzip, None, None)
-                .await
-                .expect("failed to create builder")
-                .into(),
+            writer: Writer::new(
+                &Archive::new(file_path),
+                &Encoding::Gzip,
+                None,
+                None,
+                DEFAULT_OCI_BUFFER_SIZE,
+            )
+            .await
+            .expect("failed to create builder")
+            .into(),
             duration: "1m".try_into().unwrap(),
             mode: GatherMode::Collect,
             secrets: Default::default(),
@@ -653,10 +666,16 @@ mod tests {
         let config = Config {
             client,
             filter: Arc::new(FilterGroup(vec![FilterList(vec![])])),
-            writer: Writer::new(&Archive::new(file_path), &Encoding::Path, None, None)
-                .await
-                .expect("failed to create builder")
-                .into(),
+            writer: Writer::new(
+                &Archive::new(file_path),
+                &Encoding::Path,
+                None,
+                None,
+                DEFAULT_OCI_BUFFER_SIZE,
+            )
+            .await
+            .expect("failed to create builder")
+            .into(),
             duration: "1m".try_into().unwrap(),
             mode: GatherMode::Collect,
             secrets: Default::default(),

--- a/src/gather/printers.rs
+++ b/src/gather/printers.rs
@@ -71,7 +71,7 @@ fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
         map.insert(
             "events".into(),
             vec![
-                ColumnDefinition::cel("lastTimestamp", "(now - timestamp(self.get(\"lastTimestamp\").or(self.get(\"eventTime\")))).age()"),
+                ColumnDefinition::cel("lastTimestamp", r#"(now - timestamp(self.get("lastTimestamp").or(self.get("eventTime")).or(self.get("deprecatedLastTimestamp")))).age()"#),
                 ColumnDefinition::json("type", ".type"),
                 ColumnDefinition::json("reason", ".reason"),
                 ColumnDefinition::json("object", ".metadata.name"),
@@ -456,7 +456,14 @@ impl TablePath {
                 .and_then(|json_path| json_path.query(obj).first().cloned());
         };
 
-        let program = Program::compile(cel).unwrap();
+        let program = Program::compile(cel)
+            .map_err(|e| {
+                tracing::error!(
+                    "failed to parse CEL for column {}: {cel}: {e}",
+                    self.column.source.name
+                )
+            })
+            .ok()?;
         let mut context = Context::default();
 
         register_all(&mut context);
@@ -873,6 +880,15 @@ mod tests {
         let rendered = last_timestamp_column.render(&json!({
             "lastTimestamp": null,
             "eventTime": "2026-04-15T09:12:53.577768Z",
+        }));
+
+        assert!(rendered.is_some());
+
+        // lastTimestamp is null, eventTime is null, deprecatedLastTimestamp is set
+        let rendered = last_timestamp_column.render(&json!({
+            "lastTimestamp": null,
+            "eventTime": null,
+            "deprecatedLastTimestamp": "2026-04-15T09:12:53.577768Z",
         }));
 
         assert!(rendered.is_some());

--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -538,10 +538,11 @@ impl NamespacedName for &NamedObject {
 pub struct ArchiveReader {
     archive: Archive,
     named_resources: Arc<NamedResources>,
+    buffer_size: usize,
 }
 
 impl ArchiveReader {
-    pub async fn new(archive: Archive, storage: &Storage) -> Self {
+    pub async fn new(archive: Archive, storage: &Storage, buffer_size: usize) -> Self {
         let mut named_resources = match NamedResources::from_discovery_file(
             archive.join(ArchivePath::Custom("apis.json".into())),
             storage,
@@ -570,6 +571,7 @@ impl ArchiveReader {
         Self {
             archive,
             named_resources: Arc::new(named_resources),
+            buffer_size: buffer_size.max(1),
         }
     }
 
@@ -837,7 +839,7 @@ impl Reader {
                 }
             })
             .boxed()
-            .buffered(1024)
+            .buffered(self.archive.buffer_size)
             .try_for_each(future::ok::<(), anyhow::Error>)
             .await?;
 

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -32,7 +32,7 @@ use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    cli::OCISettings,
+    cli::{DEFAULT_OCI_BUFFER_SIZE, OCISettings},
     gather::{
         reader::{ArchiveReader, Destination, Get, List, Log, NamedObject, Reader, Watch},
         representation::TypeMetaGetter,
@@ -179,7 +179,7 @@ impl Api {
         for archive in archives {
             readers.insert(
                 Api::convert_name(archive.name().to_string_lossy().to_string()),
-                ArchiveReader::new(archive, &Storage::FS).await,
+                ArchiveReader::new(archive, &Storage::FS, DEFAULT_OCI_BUFFER_SIZE).await,
             );
         }
 
@@ -251,7 +251,7 @@ impl Api {
         let mut archives = HashMap::new();
         archives.insert(
             Api::convert_name(reference.repository().to_string()),
-            ArchiveReader::new(Archive::new(search.path()), &storage).await,
+            ArchiveReader::new(Archive::new(search.path()), &storage, oci.buffer_size).await,
         );
 
         Ok(Self {

--- a/src/gather/writer.rs
+++ b/src/gather/writer.rs
@@ -32,6 +32,7 @@ use tracing::{debug, info, instrument};
 use walkdir::WalkDir;
 use zip::{ZipWriter, result::ZipError, write::SimpleFileOptions};
 
+use crate::cli::DEFAULT_OCI_BUFFER_SIZE;
 use crate::gather::{
     reader::{ArchiveReader, Reader},
     storage::Storage,
@@ -181,11 +182,12 @@ impl From<&str> for Encoding {
 /// The Writer enum represents the different archive writer implementations.
 /// Gzip uses the gzip compression format.
 /// Zip uses the zip compression format.
+/// Oci uses the remote image reference as a destination.
 pub enum Writer {
     Path(Archive),
     Gzip(Archive, Box<Builder<GzEncoder<File>>>),
     Zip(Archive, Box<ZipWriter<File>>),
-    Oci(Archive, Client, Box<Reference>, RegistryAuth),
+    Oci(Archive, Client, Box<Reference>, RegistryAuth, usize),
 }
 
 impl From<Writer> for Arc<Mutex<Writer>> {
@@ -216,7 +218,7 @@ impl Writer {
 
     /// Finish writing the archive, finalizing any compression and flushing buffers.
     pub async fn finish_oci(&self) -> anyhow::Result<()> {
-        let Self::Oci(archive, client, image_ref, auth) = self else {
+        let Self::Oci(archive, client, image_ref, auth, buffer_size) = self else {
             return Ok(());
         };
 
@@ -291,7 +293,7 @@ impl Writer {
                 }
             })
             .boxed() // Workaround to rustc issue https://github.com/rust-lang/rust/issues/104382
-            .buffer_unordered(32)
+            .buffer_unordered(*buffer_size)
             .try_for_each(future::ok::<(), anyhow::Error>)
             .await?;
 
@@ -394,7 +396,8 @@ impl Writer {
 
                 // generate diff and write
                 let original = Reader::new(
-                    ArchiveReader::new(archive.clone(), &Storage::FS).await,
+                    ArchiveReader::new(archive.clone(), &Storage::FS, DEFAULT_OCI_BUFFER_SIZE)
+                        .await,
                     Utc::now(),
                     Storage::FS,
                 )
@@ -432,7 +435,9 @@ impl Writer {
         encoding: &Encoding,
         client_config: Option<ClientConfig>,
         auth: Option<RegistryAuth>,
+        buffer_size: usize,
     ) -> anyhow::Result<Self> {
+        let buffer_size = buffer_size.max(1);
         match archive.0.parent() {
             Some(parent) if !parent.as_os_str().is_empty() => {
                 DirBuilder::new().recursive(true).create(parent)?;
@@ -460,6 +465,7 @@ impl Writer {
                 Client::new(client_config.unwrap_or_default()),
                 image_ref.clone().into(),
                 auth.unwrap_or(RegistryAuth::Anonymous),
+                buffer_size,
             ),
         })
     }
@@ -474,7 +480,10 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use crate::gather::{config::Secrets, representation::ArchivePath, writer::Representation};
+    use crate::{
+        cli::DEFAULT_OCI_BUFFER_SIZE,
+        gather::{config::Secrets, representation::ArchivePath, writer::Representation},
+    };
 
     use super::{Archive, Encoding, Writer};
 
@@ -483,7 +492,13 @@ mod tests {
         let tmp_dir = TempDir::new().expect("failed to create temp dir");
         let archive = tmp_dir.path().join("test.tar.gz");
         let archive = Archive::new(archive);
-        let result = Writer::new(&archive, &Encoding::Gzip, None, None);
+        let result = Writer::new(
+            &archive,
+            &Encoding::Gzip,
+            None,
+            None,
+            DEFAULT_OCI_BUFFER_SIZE,
+        );
 
         assert!(result.await.is_ok());
     }
@@ -493,7 +508,13 @@ mod tests {
         let tmp_dir = TempDir::new().expect("failed to create temp dir");
         let archive = tmp_dir.path().join("test.zip");
         let archive = Archive::new(archive);
-        let result = Writer::new(&archive, &Encoding::Zip, None, None);
+        let result = Writer::new(
+            &archive,
+            &Encoding::Zip,
+            None,
+            None,
+            DEFAULT_OCI_BUFFER_SIZE,
+        );
 
         assert!(result.await.is_ok());
     }
@@ -504,9 +525,15 @@ mod tests {
 
         let tmp_dir = TempDir::new().expect("failed to create temp dir");
         let archive = tmp_dir.path().join("test");
-        let mut writer = Writer::new(&Archive::new(archive.clone()), &Encoding::Gzip, None, None)
-            .await
-            .unwrap();
+        let mut writer = Writer::new(
+            &Archive::new(archive.clone()),
+            &Encoding::Gzip,
+            None,
+            None,
+            DEFAULT_OCI_BUFFER_SIZE,
+        )
+        .await
+        .unwrap();
 
         let repr = Representation::new()
             .with_data("content")
@@ -532,9 +559,15 @@ mod tests {
 
         let tmp_dir = TempDir::new().expect("failed to create temp dir");
         let archive = tmp_dir.path().join("test.zip");
-        let mut writer = Writer::new(&Archive::new(archive.clone()), &Encoding::Zip, None, None)
-            .await
-            .unwrap();
+        let mut writer = Writer::new(
+            &Archive::new(archive.clone()),
+            &Encoding::Zip,
+            None,
+            None,
+            DEFAULT_OCI_BUFFER_SIZE,
+        )
+        .await
+        .unwrap();
 
         let repr = Representation::new()
             .with_path(ArchivePath::Custom("test.txt".into()))
@@ -563,9 +596,15 @@ mod tests {
 
         let tmp_dir = TempDir::new().expect("failed to create temp dir");
         let archive = tmp_dir.path().join("cluster1/collected");
-        let mut writer = Writer::new(&Archive::new(archive.clone()), &Encoding::Path, None, None)
-            .await
-            .unwrap();
+        let mut writer = Writer::new(
+            &Archive::new(archive.clone()),
+            &Encoding::Path,
+            None,
+            None,
+            DEFAULT_OCI_BUFFER_SIZE,
+        )
+        .await
+        .unwrap();
 
         let repr = Representation::new()
             .with_data("content with secret")
@@ -588,6 +627,7 @@ mod tests {
             &Encoding::Zip,
             None,
             None,
+            DEFAULT_OCI_BUFFER_SIZE,
         )
         .await
         .unwrap();
@@ -598,9 +638,15 @@ mod tests {
     #[tokio::test]
     async fn test_try_into_writer_empty_path() {
         assert!(
-            Writer::new(&Archive::new("".into()), &Encoding::Zip, None, None)
-                .await
-                .is_err()
+            Writer::new(
+                &Archive::new("".into()),
+                &Encoding::Zip,
+                None,
+                None,
+                DEFAULT_OCI_BUFFER_SIZE,
+            )
+            .await
+            .is_err()
         );
     }
 }

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -88,6 +88,7 @@ mod test {
     use tempfile::TempDir;
     use tokio::time::timeout;
 
+    use crate::cli::DEFAULT_OCI_BUFFER_SIZE;
     use crate::filters::filter::Include;
     use crate::gather::config::GatherMode;
     use crate::{
@@ -160,10 +161,16 @@ mod test {
                 Config {
                     client: test_env.client().expect("client"),
                     filter: Arc::new(FilterGroup(vec![FilterList(vec![vec![filter].into()])])),
-                    writer: Writer::new(&Archive::new(file_path), &Encoding::Path, None, None)
-                        .await
-                        .expect("failed to create builder")
-                        .into(),
+                    writer: Writer::new(
+                        &Archive::new(file_path),
+                        &Encoding::Path,
+                        None,
+                        None,
+                        DEFAULT_OCI_BUFFER_SIZE,
+                    )
+                    .await
+                    .expect("failed to create builder")
+                    .into(),
                     secrets: Default::default(),
                     mode: GatherMode::Collect,
                     additional_logs: Default::default(),

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -163,6 +163,7 @@ mod test {
     use tempfile::TempDir;
     use tokio::time::timeout;
 
+    use crate::cli::DEFAULT_OCI_BUFFER_SIZE;
     use crate::filters::filter::Include;
     use crate::gather::config::GatherMode;
     use crate::{
@@ -224,10 +225,16 @@ mod test {
             collectable: Objects::new_typed(Config {
                 client: test_env.client().expect("client"),
                 filter: Arc::new(FilterGroup(vec![FilterList(vec![vec![filter].into()])])),
-                writer: Writer::new(&Archive::new(file_path), &Encoding::Path, None, None)
-                    .await
-                    .expect("failed to create builder")
-                    .into(),
+                writer: Writer::new(
+                    &Archive::new(file_path),
+                    &Encoding::Path,
+                    None,
+                    None,
+                    DEFAULT_OCI_BUFFER_SIZE,
+                )
+                .await
+                .expect("failed to create builder")
+                .into(),
                 secrets: Default::default(),
                 mode: GatherMode::Collect,
                 additional_logs: Default::default(),

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -112,6 +112,7 @@ mod test {
     use kube::core::{ApiResource, DynamicObject, params::PostParams};
 
     use crate::{
+        cli::DEFAULT_OCI_BUFFER_SIZE,
         filters::{
             filter::{FilterGroup, FilterList, Include},
             namespace::Namespace,
@@ -179,6 +180,7 @@ mod test {
                     &Encoding::Path,
                     None,
                     None,
+                    DEFAULT_OCI_BUFFER_SIZE,
                 )
                 .await
                 .expect("failed to create builder")
@@ -221,6 +223,7 @@ mod test {
                     &Encoding::Path,
                     None,
                     None,
+                    DEFAULT_OCI_BUFFER_SIZE,
                 )
                 .await
                 .expect("failed to create builder")
@@ -260,6 +263,7 @@ mod test {
                     &Encoding::Path,
                     None,
                     None,
+                    DEFAULT_OCI_BUFFER_SIZE,
                 )
                 .await
                 .expect("failed to create builder")


### PR DESCRIPTION
Fix CEL failure for events, which use `deprecatedLastTimestamp` field.

Additionally, make --buffer-size for parallel OCI download/upload configurable with default to 32. Existing hardcoded 1024 number for parallel downloads, stalled download for larger number of events in the cluster.