### PR TITLE
combine objects of one type into single oci layer

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -586,7 +586,7 @@ impl GatherSettings {
         match &self.kubeconfig_secret {
             Some(secret) => {
                 let kubeconfigs = secret.get_config(origin).await?;
-                for kubeconfig in kubeconfigs {
+                if let Some(kubeconfig) = kubeconfigs.into_iter().next() {
                     match KubeconfigFile(kubeconfig)
                         .client(self.insecure_skip_tls_verify.unwrap_or_default())
                         .await

--- a/src/filters/filter.rs
+++ b/src/filters/filter.rs
@@ -117,7 +117,7 @@ impl<R: ResourceThreadSafe> Filter<R> for FilterList {
     }
 }
 
-fn eval_exclude<R, F>(filters: &Vec<F>, obj: &R, gvk: &GroupVersionKind) -> bool
+fn eval_exclude<R, F>(filters: &[F], obj: &R, gvk: &GroupVersionKind) -> bool
 where
     F: Filter<R>,
     R: ResourceThreadSafe,

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -14,7 +14,6 @@ use actix_web::{
 };
 use anyhow::Context as _;
 use async_stream::stream;
-use cached::proc_macro::cached;
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use k8s_openapi::serde_json::{self, json};
@@ -26,7 +25,7 @@ use kube::{
         watch::{Bookmark, BookmarkMeta},
     },
 };
-use oci_client::{Client, Reference};
+use oci_client::{Client, Reference, manifest::OciImageManifest};
 use serde::Deserialize;
 use tokio::sync::oneshot;
 use tokio::time::{Instant, sleep};
@@ -36,8 +35,8 @@ use crate::{
     gather::{
         reader::{ArchiveReader, Destination, Get, List, Log, NamedObject, Reader, Watch},
         representation::TypeMetaGetter,
-        storage::{OCIState, Storage},
-        writer::Archive,
+        storage::{Descriptor, OCIState, Storage},
+        writer::{Archive, YamlPath},
     },
 };
 
@@ -221,24 +220,17 @@ impl Api {
         let previous_context = config.current_context;
         config.current_context = None;
 
-        let config = Api::prepare_kubeconfig(reference.repository().to_string(), socket);
+        let config = config.merge(Api::prepare_kubeconfig(
+            reference.repository().to_string(),
+            socket,
+        ))?;
 
         serde_saphyr::to_io_writer(&mut File::create(&kubeconfig_path)?, &config)?;
 
         let client = Client::new(oci.to_client_config());
         let auth = oci.to_auth();
         let (manifest, _) = client.pull_image_manifest(&reference, &auth).await?;
-        let mut index = HashMap::new();
-
-        for layer in manifest.layers {
-            let Some(annotations) = layer.annotations.clone() else {
-                anyhow::bail!("manifest layer contains no org.opencontainers.image.title annoation")
-            };
-            let path = &annotations["org.opencontainers.image.title"];
-            index.insert(PathBuf::from(path), layer);
-        }
-
-        let index = Arc::new(index);
+        let index = Arc::new(Self::collect_index(&client, &reference, manifest).await?);
 
         let storage = Storage::new(Some(OCIState {
             reference: reference.clone(),
@@ -264,6 +256,53 @@ impl Api {
             },
             socket,
         })
+    }
+
+    async fn collect_index(
+        client: &Client,
+        reference: &Reference,
+        manifest: OciImageManifest,
+    ) -> anyhow::Result<HashMap<PathBuf, Descriptor>> {
+        let mut index = HashMap::new();
+
+        for layer in manifest.layers {
+            let Some(annotations) = layer.annotations.clone() else {
+                anyhow::bail!("manifest layer contains no org.opencontainers.image.title annoation")
+            };
+            let path = &annotations["org.opencontainers.image.title"];
+            index.insert(PathBuf::from(path), Descriptor::OciDescriptor(layer));
+        }
+
+        let Some(index_layer) = index.get(&PathBuf::from("index.yaml")) else {
+            return Ok(index);
+        };
+
+        let mut data = vec![];
+        client
+            .pull_blob(reference, index_layer.deref(), &mut data)
+            .await?;
+        let resource_paths: Vec<YamlPath> = serde_saphyr::from_slice(&data)?;
+        for yaml_path in resource_paths {
+            let resource_path = yaml_path.path;
+            let Some(parent_path) = resource_path.parent() else {
+                anyhow::bail!(format!(
+                    "index layer must reference a parent list object: {resource_path:?}"
+                ))
+            };
+
+            let Some(parent) = index.get(&parent_path.with_extension("yaml")) else {
+                anyhow::bail!(format!(
+                    "index layer must reference a yaml list object: {resource_path:?}"
+                ))
+            };
+
+            index.insert(
+                resource_path,
+                Descriptor::ListOciDescriptor(parent.deref().clone(), yaml_path.from, yaml_path.to),
+            );
+        }
+
+        Ok(index)
     }
 
     fn convert_name(name: String) -> String {
@@ -377,7 +416,8 @@ async fn version(
         .to_reader(archive.clone())
         .await
         .map_err(error::ErrorServiceUnavailable)?;
-    let path = load_raw(reader, ArchivePath::Custom("version.yaml".into()))
+    let path = reader
+        .load_raw(ArchivePath::Custom("version.yaml".into()))
         .await
         .map_err(error::ErrorNotFound)?;
     let version: serde_json::Value =
@@ -424,7 +464,8 @@ async fn api(
         .await
         .map_err(error::ErrorServiceUnavailable)?;
 
-    Ok(load_raw(reader, ArchivePath::Custom("api.json".into()))
+    Ok(reader
+        .load_raw(ArchivePath::Custom("api.json".into()))
         .await
         .map_err(error::ErrorNotFound)?
         .customize()
@@ -453,7 +494,8 @@ async fn apis(
         .await
         .map_err(error::ErrorServiceUnavailable)?;
 
-    Ok(load_raw(reader, ArchivePath::Custom("apis.json".into()))
+    Ok(reader
+        .load_raw(ArchivePath::Custom("apis.json".into()))
         .await
         .map_err(error::ErrorNotFound)?
         .customize()
@@ -462,7 +504,6 @@ async fn apis(
         .insert_header(("X-Varied-Accept", v2::ACCEPT_AGGREGATED_DISCOVERY_V2)))
 }
 
-// TODO: I want to log all query parameters passed in stdout, as a qick debug. Even those which are not defined here
 #[get("{server}/api/{version}/{kind}")]
 async fn api_list(
     accept: Header<Accept>,
@@ -538,9 +579,9 @@ async fn list_items(
     let selector = query.0;
     Ok(match accept.0.as_slice() {
         [QualityItem { item, .. }, ..] if item.to_string().contains("as=Table") => {
-            load_table(reader, list, selector).await?
+            reader.load_table(list, selector).await?
         }
-        _ => load_list(reader, list, selector).await?,
+        _ => reader.list(list, selector).await?,
     })
 }
 
@@ -553,9 +594,9 @@ async fn watch_events(
     let selector = query.0;
     Ok(match accept.0.as_slice() {
         [QualityItem { item, .. }, ..] if item.to_string().contains("as=Table") => {
-            watch_table_events(reader.clone(), list, selector).await?
+            reader.watch_table_events(list, selector).await?
         }
-        _ => watch_events_cached(reader.clone(), list, selector).await?,
+        _ => reader.watch_events(list, selector).await?,
     })
 }
 
@@ -689,7 +730,8 @@ async fn logs_get(
         .await
         .map_err(error::ErrorServiceUnavailable)?;
     let get = archive.named_object_from_get(get.clone());
-    load_raw(reader, get.get_logs_path(query.deref()))
+    reader
+        .load_raw(get.get_logs_path(query.deref()))
         .await
         .map_err(error::ErrorNotFound)
 }
@@ -701,51 +743,5 @@ async fn get_item(get: Path<Get>, state: web::Data<ApiState>) -> anyhow::Result<
         .ok_or(anyhow::anyhow!("Server not found"))?;
     let reader = state.to_reader(archive.clone()).await?;
     let get = archive.named_object_from_get(get.clone());
-    load(reader, get).await
-}
-
-#[cached(result)]
-async fn load_raw(reader: Reader, path: ArchivePath) -> anyhow::Result<String> {
-    reader.load_raw(path).await
-}
-
-#[cached(result)]
-async fn load(reader: Reader, get: NamedObject) -> anyhow::Result<serde_json::Value> {
     reader.load(get).await
-}
-
-#[cached(result)]
-async fn load_list(
-    reader: Reader,
-    list: NamedObject,
-    selector: Selector,
-) -> anyhow::Result<serde_json::Value> {
-    reader.list(list, selector).await
-}
-
-#[cached(result)]
-async fn load_table(
-    reader: Reader,
-    list: NamedObject,
-    selector: Selector,
-) -> anyhow::Result<serde_json::Value> {
-    reader.load_table(list, selector).await
-}
-
-#[cached(result)]
-async fn watch_table_events(
-    reader: Reader,
-    list: NamedObject,
-    selector: Selector,
-) -> anyhow::Result<Vec<serde_json::Value>> {
-    reader.watch_table_events(list, selector).await
-}
-
-#[cached(result)]
-async fn watch_events_cached(
-    reader: Reader,
-    list: NamedObject,
-    selector: Selector,
-) -> anyhow::Result<Vec<serde_json::Value>> {
-    reader.watch_events(list, selector).await
 }

--- a/src/gather/storage.rs
+++ b/src/gather/storage.rs
@@ -1,6 +1,13 @@
-use std::{collections::HashMap, fs::File, io::Read as _, path::PathBuf, pin::pin, sync::Arc};
+use std::{
+    collections::HashMap, fs::File, io::Read as _, ops::Deref as _, path::PathBuf, pin::pin,
+    sync::Arc,
+};
 
 use anyhow::bail;
+use base64::{Engine as _, prelude::BASE64_STANDARD};
+use cached::proc_macro::cached;
+use derive_more::Deref;
+use flate2::read::GzDecoder;
 use oci_client::{Client, Reference, manifest::OciDescriptor, secrets::RegistryAuth};
 use tokio::io::{AsyncWrite, AsyncWriteExt as _};
 
@@ -15,7 +22,13 @@ pub struct OCIState {
     pub reference: Reference,
     pub auth: RegistryAuth,
     pub client: Client,
-    pub index: Arc<HashMap<PathBuf, OciDescriptor>>,
+    pub index: Arc<HashMap<PathBuf, Descriptor>>,
+}
+
+#[derive(Clone, Deref)]
+pub enum Descriptor {
+    OciDescriptor(OciDescriptor),
+    ListOciDescriptor(#[deref] OciDescriptor, usize, usize),
 }
 
 impl Storage {
@@ -34,58 +47,20 @@ impl Storage {
                 File::read_to_string(&mut file, &mut data)?;
                 Ok(data)
             }
-            Storage::OCI(OCIState {
-                reference,
-                client,
-                index,
-                auth,
-            }) => {
-                let layer = index
-                    .get(&path)
-                    .ok_or_else(|| anyhow::anyhow!("missing OCI layer entry for path: {path:?}"))?;
-                Ok(Storage::read_raw_oci(client, reference, layer, auth).await?)
-            }
+            Storage::OCI(oci_state) => Ok(oci_state.read_raw(path).await?),
         }
     }
 
-    async fn read_raw_oci(
-        client: &Client,
-        reference: &Reference,
-        layer: &OciDescriptor,
-        auth: &RegistryAuth,
-    ) -> anyhow::Result<String> {
-        client
-            .store_auth_if_needed(reference.registry(), auth)
-            .await;
-        let mut data = vec![];
-        client.pull_blob(reference, layer, &mut data).await?;
-        Ok(String::from_utf8(data)?)
-    }
-
     pub async fn read<W: AsyncWrite>(&self, path: PathBuf, out: W) -> anyhow::Result<usize> {
-        let mut out = pin!(out);
         match self {
             Storage::FS => {
                 let mut file = File::open(path)?;
                 let mut data = String::new();
                 File::read_to_string(&mut file, &mut data)?;
+                let mut out = pin!(out);
                 Ok(out.write(data.as_bytes()).await?)
             }
-            Storage::OCI(OCIState {
-                reference,
-                client,
-                index,
-                auth,
-            }) => {
-                let layer = index
-                    .get(&path)
-                    .ok_or_else(|| anyhow::anyhow!("missing OCI layer entry for path: {path:?}"))?;
-                client
-                    .store_auth_if_needed(reference.registry(), auth)
-                    .await;
-                client.pull_blob(reference, layer, &mut out).await?;
-                Ok(layer.size as usize)
-            }
+            Storage::OCI(oci_state) => Ok(oci_state.read(path, out).await?),
         }
     }
 
@@ -123,4 +98,80 @@ impl Storage {
         };
         Ok(paths)
     }
+}
+
+impl OCIState {
+    async fn read_raw(&self, path: PathBuf) -> anyhow::Result<String> {
+        let layer = self
+            .index
+            .get(&path)
+            .ok_or_else(|| anyhow::anyhow!("missing OCI layer entry for path: {path:?}"))?;
+        let mut data = Vec::with_capacity(layer.size as usize);
+        self.pull_blob(layer, &mut data).await?;
+        Ok(String::from_utf8(data)?)
+    }
+
+    async fn read<W: AsyncWrite>(&self, path: PathBuf, out: W) -> anyhow::Result<usize> {
+        let layer = self
+            .index
+            .get(&path)
+            .ok_or_else(|| anyhow::anyhow!("missing OCI layer entry for path: {path:?}"))?;
+
+        let size = self.pull_blob(layer, out).await?;
+        Ok(size)
+    }
+
+    async fn pull_blob<W: AsyncWrite>(
+        &self,
+        descriptor: &Descriptor,
+        out: W,
+    ) -> anyhow::Result<usize> {
+        let data = pull_blob_cached(
+            &self.client,
+            &self.reference,
+            &self.auth,
+            descriptor.deref(),
+            matches!(descriptor, Descriptor::ListOciDescriptor(..)),
+        )
+        .await?;
+        let mut out = pin!(out);
+
+        let Descriptor::ListOciDescriptor(_, from, to) = descriptor else {
+            out.write_all(&data).await?;
+            return Ok(data.len());
+        };
+
+        out.write_all(&data[*from..*to]).await?;
+        Ok(*to - *from)
+    }
+}
+
+#[cached(
+    result = true,
+    key = "String",
+    convert = r#"{ format!("{}@{}", reference, descriptor.digest) }"#
+)]
+async fn pull_blob_cached(
+    client: &Client,
+    reference: &Reference,
+    auth: &RegistryAuth,
+    descriptor: &OciDescriptor,
+    encoded: bool,
+) -> anyhow::Result<Vec<u8>> {
+    client
+        .store_auth_if_needed(reference.registry(), auth)
+        .await;
+    let mut out = Vec::with_capacity(descriptor.size as usize);
+    client.pull_blob(reference, &descriptor, &mut out).await?;
+
+    if !encoded {
+        return Ok(out);
+    }
+
+    let data = BASE64_STANDARD.decode(out)?;
+    let mut dec = GzDecoder::new(data.as_slice());
+
+    let mut objects = vec![];
+    dec.read_to_end(&mut objects)?;
+    Ok(objects)
 }

--- a/src/gather/writer.rs
+++ b/src/gather/writer.rs
@@ -1,9 +1,14 @@
 use anyhow::Context;
 use backon::{ExponentialBuilder, Retryable};
+use base64::{Engine as _, prelude::BASE64_STANDARD};
 use flate2::{Compression, write::GzEncoder};
 
 use chrono::Utc;
-use futures::{StreamExt as _, TryStreamExt as _, future, stream};
+use futures::{
+    StreamExt as _, TryStreamExt as _,
+    future::{self},
+    stream, try_join,
+};
 use json_patch::diff;
 use k8s_openapi::serde_json;
 use oci_client::{
@@ -13,10 +18,11 @@ use oci_client::{
     manifest::{IMAGE_LAYER_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE, OciDescriptor, OciImageManifest},
     secrets::RegistryAuth,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
 use std::{
     borrow::Cow,
+    collections::BTreeMap,
     ffi::OsStr,
     fmt::Display,
     fs::{DirBuilder, File},
@@ -187,7 +193,25 @@ pub enum Writer {
     Path(Archive),
     Gzip(Archive, Box<Builder<GzEncoder<File>>>),
     Zip(Archive, Box<ZipWriter<File>>),
-    Oci(Archive, Client, Box<Reference>, RegistryAuth, usize),
+    Oci(OCIState),
+}
+
+// OCIState holds current OCI writer destination state
+pub struct OCIState {
+    archive: Archive,
+    client: Client,
+    image_ref: Box<Reference>,
+    auth: RegistryAuth,
+    buffer_size: usize,
+}
+
+// YamlPath contains a full path in the yaml file in archive
+// and a range of bytes to extract yaml from a list
+#[derive(Serialize, Deserialize)]
+pub struct YamlPath {
+    pub path: PathBuf,
+    pub from: usize,
+    pub to: usize,
 }
 
 impl From<Writer> for Arc<Mutex<Writer>> {
@@ -218,113 +242,9 @@ impl Writer {
 
     /// Finish writing the archive, finalizing any compression and flushing buffers.
     pub async fn finish_oci(&self) -> anyhow::Result<()> {
-        let Self::Oci(archive, client, image_ref, auth, buffer_size) = self else {
-            return Ok(());
-        };
-
-        info!("Pushing image: {:?}", image_ref);
-        client
-            .store_auth_if_needed(image_ref.resolve_registry(), auth)
-            .await;
-
-        let config = Config::new(b"{}".to_vec(), OCI_IMAGE_MEDIA_TYPE.to_string(), None);
-        let paths = glob::glob(&format!(
-            "{}/**/*",
-            archive
-                .path()
-                .to_str()
-                .ok_or(anyhow::anyhow!("archive path is not convertable to string"))?,
-        ))?;
-
-        let layers = Arc::new(Mutex::new(vec![]));
-        // Upload layers
-        stream::iter(paths.into_iter())
-            .map(|path| {
-                let layers = layers.clone();
-                async move {
-                    let path = path?;
-                    if path.is_dir() {
-                        return anyhow::Result::Ok(());
-                    }
-                    let archive_path = path.clone();
-                    let archive_path = archive_path
-                        .to_str()
-                        .ok_or(anyhow::anyhow!("file path is not convertable to string"))?;
-                    let mut file =
-                        File::open(path).context(format!("failed to open file {archive_path}"))?;
-                    let mut data = String::new();
-                    File::read_to_string(&mut file, &mut data)
-                        .context(format!("failed to read file {archive_path}"))?;
-                    if data.is_empty() {
-                        // That could only happen for empty logs, so we publish an empty json instead
-                        // as ghcr doesn't allow empty layers
-                        data = "{}".to_string();
-                    };
-                    let size = data.len() as i64;
-                    let digest = format!(
-                        "sha256:{}",
-                        hex::encode(sha2::Sha256::digest(data.as_bytes()))
-                    );
-                    {
-                        layers.lock().await.push(OciDescriptor {
-                            urls: None,
-                            media_type: IMAGE_LAYER_MEDIA_TYPE.to_string(),
-                            digest: digest.clone(),
-                            size,
-                            annotations: Some(
-                                [(
-                                    "org.opencontainers.image.title".to_string(),
-                                    archive_path.to_string(),
-                                )]
-                                .into(),
-                            ),
-                        });
-                    }
-
-                    info!("Pushing layer: {:?}", archive_path);
-                    let push = || client.push_blob(image_ref, data.clone(), &digest);
-                    push.retry(ExponentialBuilder::default().with_max_times(20).with_max_delay(Duration::from_secs(10)).with_jitter())
-                        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
-                        .notify(|e, dur| debug!("Pushing layer: {archive_path:?} - retry after {dur:?} due to {e:?}"))
-                        .await
-                        .context(format!("failed to push layer for file {archive_path}"))?;
-
-                    anyhow::Result::Ok(())
-                }
-            })
-            .boxed() // Workaround to rustc issue https://github.com/rust-lang/rust/issues/104382
-            .buffer_unordered(*buffer_size)
-            .try_for_each(future::ok::<(), anyhow::Error>)
-            .await?;
-
-        let mut manifest = OciImageManifest::default();
-        manifest.config.media_type = config.media_type.to_string();
-        manifest.config.size = config.data.len() as i64;
-        manifest.config.digest =
-            format!("sha256:{}", hex::encode(sha2::Sha256::digest(&config.data)));
-        manifest.layers = layers.lock().await.clone();
-        manifest.layers.sort_by(|a, b| a.digest.cmp(&b.digest));
-
-        let push = || client.push_blob(image_ref, config.data.clone(), &manifest.config.digest);
-        push.retry(
-            ExponentialBuilder::default()
-                .with_max_times(20)
-                .with_max_delay(Duration::from_secs(10))
-                .with_jitter(),
-        )
-        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
-        .await?;
-
-        let manifest = &manifest.into();
-        let push = || client.push_manifest(image_ref, manifest);
-        push.retry(
-            ExponentialBuilder::default()
-                .with_max_times(20)
-                .with_max_delay(Duration::from_secs(10))
-                .with_jitter(),
-        )
-        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
-        .await?;
+        if let Writer::Oci(ocistate) = self {
+            return ocistate.publish_image().await;
+        }
 
         Ok(())
     }
@@ -338,7 +258,11 @@ impl Writer {
         let data = repr.data();
 
         match self {
-            Self::Path(Archive(archive)) | Self::Oci(Archive(archive), ..) => {
+            Self::Path(Archive(archive))
+            | Self::Oci(OCIState {
+                archive: Archive(archive),
+                ..
+            }) => {
                 let file = archive.join(archive_path);
                 if !file.exists() {
                     DirBuilder::new()
@@ -460,14 +384,261 @@ impl Writer {
                     archive.0.with_extension("zip"),
                 )?)),
             ),
-            Encoding::Oci(image_ref) => Self::Oci(
-                archive.clone(),
-                Client::new(client_config.unwrap_or_default()),
-                image_ref.clone().into(),
-                auth.unwrap_or(RegistryAuth::Anonymous),
+            Encoding::Oci(image_ref) => Self::Oci(OCIState {
+                archive: archive.clone(),
+                client: Client::new(client_config.unwrap_or_default()),
+                image_ref: image_ref.clone().into(),
+                auth: auth.unwrap_or(RegistryAuth::Anonymous),
                 buffer_size,
-            ),
+            }),
         })
+    }
+}
+
+impl OCIState {
+    #[instrument(skip_all, err)]
+    async fn publish_image(&self) -> anyhow::Result<()> {
+        info!("Pushing image: {:?}", self.image_ref);
+        self.client
+            .store_auth_if_needed(self.image_ref.resolve_registry(), &self.auth)
+            .await;
+
+        let config = Config::new(b"{}".to_vec(), OCI_IMAGE_MEDIA_TYPE.to_string(), None);
+        let paths = glob::glob(&format!(
+            "{}/**/*",
+            self.archive
+                .path()
+                .to_str()
+                .ok_or(anyhow::anyhow!("archive path is not convertable to string"))?,
+        ))?;
+
+        let resource_paths = Arc::new(Mutex::new(Default::default()));
+        let non_resource_paths: Vec<PathBuf> = stream::iter(paths.into_iter())
+            .filter_map(|path| Self::prepare_resource_layer(path, resource_paths.clone()))
+            .collect()
+            .await;
+
+        // Upload layers
+        let layers = Arc::new(Mutex::new(vec![]));
+        let raw_layers = stream::iter(non_resource_paths.into_iter())
+            .map(|path| self.push_oci_archive_layer(path, layers.clone()))
+            .buffer_unordered(self.buffer_size)
+            .try_for_each(future::ok::<(), anyhow::Error>);
+
+        let resource_layer_entries = { resource_paths.lock().await.clone() };
+        let resources = stream::iter(resource_layer_entries)
+            .filter_map(|(p, yamls)| {
+                future::ready(
+                    Self::combined_oci_archive_layer(&yamls)
+                        .ok()
+                        .map(|data| (p + ".yaml", data)),
+                )
+            })
+            .map(|(p, data)| self.push_oci_layer(p, data, layers.clone()))
+            .buffer_unordered(self.buffer_size)
+            .try_for_each(future::ok::<(), anyhow::Error>);
+
+        let yamls = Self::prepare_index(resource_paths.lock().await.values().cloned().collect())?;
+        let yamls =
+            serde_saphyr::to_string(&yamls).context("unable to collect yamls index file")?;
+
+        let index_layer = self.push_oci_layer("index.yaml".to_string(), yamls, layers.clone());
+
+        try_join!(resources, raw_layers, index_layer).context("failed to upload OCI layers")?;
+
+        let mut manifest = OciImageManifest::default();
+        manifest.config.media_type = config.media_type.to_string();
+        manifest.config.size = config.data.len() as i64;
+        manifest.config.digest =
+            format!("sha256:{}", hex::encode(sha2::Sha256::digest(&config.data)));
+        manifest.layers = layers.lock().await.clone();
+        manifest.layers.sort_by(|a, b| a.digest.cmp(&b.digest));
+
+        info!("Pushing config: {}", self.image_ref);
+        let push = || {
+            self.client.push_blob(
+                &self.image_ref,
+                config.data.clone(),
+                &manifest.config.digest,
+            )
+        };
+        push.retry(
+            ExponentialBuilder::default()
+                .with_max_times(20)
+                .with_max_delay(Duration::from_secs(10))
+                .with_jitter(),
+        )
+        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
+        .await?;
+
+        info!("Pushing manifest: {}", self.image_ref);
+        let manifest = &manifest.into();
+        let push = || self.client.push_manifest(&self.image_ref, manifest);
+        push.retry(
+            ExponentialBuilder::default()
+                .with_max_times(20)
+                .with_max_delay(Duration::from_secs(10))
+                .with_jitter(),
+        )
+        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
+        .await?;
+
+        Ok(())
+    }
+
+    fn prepare_index(yamls: Vec<Vec<PathBuf>>) -> anyhow::Result<Vec<YamlPath>> {
+        let mut list = vec![];
+        for yaml_list in yamls {
+            let mut index = 0;
+            for yaml in yaml_list {
+                let path = yaml.to_string_lossy();
+                let file = File::open(&yaml).context(format!("failed to open file {path}"))?;
+                let value: serde_json::Value = serde_saphyr::from_reader(file)
+                    .context(format!("failed to read file {path}"))?;
+                let data = serde_saphyr::to_string(&value)
+                    .context(format!("failed to serialize file {path}"))?;
+
+                list.push(YamlPath {
+                    path: yaml,
+                    from: index,
+                    to: {
+                        index += data.len();
+                        index
+                    },
+                });
+                index += 4
+            }
+        }
+
+        Ok(list)
+    }
+
+    async fn prepare_resource_layer(
+        path: glob::GlobResult,
+        resource_layers: Arc<Mutex<BTreeMap<String, Vec<PathBuf>>>>,
+    ) -> Option<PathBuf> {
+        let path = path.ok()?;
+
+        if path.is_dir() {
+            return Some(path);
+        }
+
+        let Some(parent) = path.parent() else {
+            return Some(path);
+        };
+
+        let Some(ext) = path.extension() else {
+            return Some(path);
+        };
+
+        if ext != "yaml" || path.to_string_lossy().ends_with("version.yaml") {
+            return Some(path);
+        }
+
+        let parent = parent.to_str()?;
+
+        debug!("Inserting path {:?} with parent {:?}", path, parent);
+        resource_layers
+            .lock()
+            .await
+            .entry(parent.to_string())
+            .or_default()
+            .push(path);
+
+        None
+    }
+
+    async fn push_oci_layer(
+        &self,
+        archive_path: String,
+        mut data: String,
+        layers: Arc<Mutex<Vec<OciDescriptor>>>,
+    ) -> anyhow::Result<()> {
+        if data.is_empty() {
+            // That could only happen for empty logs, so we publish an empty json instead
+            // as ghcr doesn't allow empty layers
+            data = "{}".to_string();
+        };
+        let size = data.len() as i64;
+        let digest = format!(
+            "sha256:{}",
+            hex::encode(sha2::Sha256::digest(data.as_bytes()))
+        );
+        {
+            layers.lock().await.push(OciDescriptor {
+                urls: None,
+                media_type: IMAGE_LAYER_MEDIA_TYPE.to_string(),
+                digest: digest.clone(),
+                size,
+                annotations: Some(
+                    [(
+                        "org.opencontainers.image.title".to_string(),
+                        archive_path.to_string(),
+                    )]
+                    .into(),
+                ),
+            });
+        }
+
+        info!("Pushing layer: {:?}", archive_path);
+        let push = || {
+            self.client
+                .push_blob(&self.image_ref, data.clone(), &digest)
+        };
+        push.retry(
+            ExponentialBuilder::default()
+                .with_max_times(20)
+                .with_max_delay(Duration::from_secs(10))
+                .with_jitter(),
+        )
+        .when(|e| matches!(e, OciDistributionError::ServerError { code, .. } if *code == 429 ))
+        .notify(|e, dur| {
+            debug!("Pushing layer: {archive_path:?} - retry after {dur:?} due to {e:?}")
+        })
+        .await
+        .context(format!("failed to push layer for file {archive_path}"))?;
+
+        anyhow::Result::Ok(())
+    }
+
+    #[instrument(skip_all, err)]
+    fn combined_oci_archive_layer(yamls: &Vec<PathBuf>) -> anyhow::Result<String> {
+        let mut files: Vec<serde_json::Value> = vec![];
+        for yaml in yamls {
+            let path = yaml.to_string_lossy();
+            let file = File::open(yaml).context(format!("failed to open file {path}"))?;
+            files.push(
+                serde_saphyr::from_reader(file).context(format!("failed to read file {path}"))?,
+            );
+        }
+
+        let mut enc = GzEncoder::new(vec![], Compression::best());
+        let data = serde_saphyr::to_string_multiple(&files)
+            .context("failed to serialize a list of yamls")?;
+        enc.write_all(data.as_bytes())?;
+
+        Ok(BASE64_STANDARD.encode(enc.finish()?))
+    }
+
+    async fn push_oci_archive_layer(
+        &self,
+        path: PathBuf,
+        layers: Arc<Mutex<Vec<OciDescriptor>>>,
+    ) -> anyhow::Result<()> {
+        if path.is_dir() {
+            return anyhow::Result::Ok(());
+        }
+        let archive_path = path.clone();
+        let archive_path = archive_path
+            .to_str()
+            .ok_or(anyhow::anyhow!("file path is not convertable to string"))?;
+        let mut file = File::open(path).context(format!("failed to open file {archive_path}"))?;
+        let mut data = String::new();
+        File::read_to_string(&mut file, &mut data)
+            .context(format!("failed to read file {archive_path}"))?;
+
+        self.push_oci_layer(archive_path.to_string(), data, layers)
+            .await
     }
 }
 


### PR DESCRIPTION
Github registry has 1m push limit of 2000 layers from one token. This limit is non configurable, and is easily exhausted by 1 big cluster collection, or multiple of small ones (TIL). That leads to severely delayed archive publishing to OCI, frequently north of 20m to publish one OCI archive, while collection takes under a minute.

This PR performs simple optimization effort, by switching OCI layering logic to be more complex, by publishing a list of yaml resources in a single layer, instead of a layer per each resource. So actual number of layers is now roughly:
`NS * NS ResourceType + ClusterWide ResourceType + X * current logs + Y * previous logs + 1 * index.yaml`

It also offloads majority of OCI `manifest` file to a single `index.yaml` layer, containing all paths of individual resources of any type, as they appear in a list.

As a result of this change:

1. Cold get of a large number of events across the cluster snapshot in OCI - `3.8s`:
```bash
% time kubectl get events -A | wc -l
    1054
kubectl get events -A  0.08s user 0.03s system 2% cpu 3.773 total
```

2. Upload of a cluster image in ghcr OCI with 4k+ resources/logs and 1054 events alone (from already prepared snapshot):
```
../target/debug/kubectl-crust-gather collect -r 19.97s user 0.77s system 52% cpu 39.165 total
```