### PR TITLE
`--served-crs-only`: removes CRD versions not marked both served and storage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,7 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 pub struct Cli {
     /// Controls the verbosity of the output.
     ///
-    /// OneOf: OFF, ERROR, WARN, INFO, DEBUG, TRACE
+    /// `OneOf`: OFF, ERROR, WARN, INFO, DEBUG, TRACE
     #[arg(short, long, default_value = "INFO", global = true)]
     verbosity: LevelFilter,
 
@@ -124,14 +124,14 @@ pub enum Commands {
 impl Commands {
     pub async fn run(self) -> anyhow::Result<()> {
         match self {
-            Commands::Collect { config } => {
+            Self::Collect { config } => {
                 Into::<GatherCommands>::into(config)
                     .load()
                     .await?
                     .collect()
                     .await
             }
-            Commands::CollectFromConfig { source, overrides } => {
+            Self::CollectFromConfig { source, overrides } => {
                 source
                     .gather(overrides.origin_client().await?)
                     .await?
@@ -141,11 +141,9 @@ impl Commands {
                     .collect()
                     .await
             }
-            Commands::Serve { serve } => {
-                serve.get_api().await?.serve().await.map_err(|e| anyhow!(e))
-            }
-            Commands::Mcp => mcp_server::run().await,
-            Commands::Record { config } => {
+            Self::Serve { serve } => serve.get_api().await?.serve().await.map_err(|e| anyhow!(e)),
+            Self::Mcp => mcp_server::run().await,
+            Self::Record { config } => {
                 let config = GatherCommands {
                     mode: GatherMode::Record,
                     ..config
@@ -156,7 +154,7 @@ impl Commands {
                     .collect()
                     .await
             }
-            Commands::RecordFromConfig { source, overrides } => {
+            Self::RecordFromConfig { source, overrides } => {
                 let config = source
                     .gather(overrides.origin_client().await?)
                     .await?
@@ -180,9 +178,9 @@ pub struct ConfigSource {
     /// Example file:
     ///
     /// filters:
-    /// - include_namespace:
+    /// - `include_namespace`:
     ///   - default
-    ///   include_kind:
+    ///   `include_kind`:
     ///   - Pod
     /// settings:
     ///   secret:
@@ -200,15 +198,15 @@ pub struct ConfigSource {
     /// Example content:
     ///
     /// apiVersion: v1
-    /// kind: ConfigMap
+    /// kind: `ConfigMap`
     /// metadata:
     ///   name: crust-gather-config
     /// data:
     ///   config: |
     ///     filters:
-    ///     - include_namespace:
+    ///     - `include_namespace`:
     ///       - default
-    ///       include_kind:
+    ///       `include_kind`:
     ///       - Pod
     ///     settings:
     ///       secret:
@@ -263,6 +261,7 @@ pub struct GatherCommands {
 }
 
 impl GatherCommands {
+    #[must_use]
     pub fn merge(&self, other: GatherSettings) -> Self {
         Self {
             mode: self.mode.clone(),
@@ -275,6 +274,7 @@ impl GatherCommands {
 }
 
 impl GatherSettings {
+    #[must_use]
     pub fn merge(&self, other: Self) -> Self {
         Self {
             kubeconfig: other.kubeconfig.or(self.kubeconfig.clone()),
@@ -339,7 +339,7 @@ pub struct GatherSettings {
     /// Encoding for the output file.
     /// By default there is no encoding and data is written to the filesystem.
     /// The available options are:
-    /// - gzip: GZip encoded tar.
+    /// - gzip: `GZip` encoded tar.
     /// - zip: ZIP encoded.
     ///
     /// Example:
@@ -360,7 +360,7 @@ pub struct GatherSettings {
     /// Can be specified multiple times to exclude multiple values.
     ///
     /// Example:
-    ///     --secret=MY_ENV_SECRET_DATA --secret=SOME_OTHER_SECRET_DATA
+    ///     --`secret=MY_ENV_SECRET_DATA` --`secret=SOME_OTHER_SECRET_DATA`
     #[arg(short, long = "secret", action = ArgAction::Append)]
     #[serde(default)]
     pub secrets: Vec<String>,
@@ -466,9 +466,9 @@ pub struct OCIReference {
 impl From<OCIReference> for Reference {
     fn from(reference: OCIReference) -> Self {
         let mut r = if let Some(tag) = reference.tag {
-            Reference::with_tag(reference.registry, reference.repository, tag)
+            Self::with_tag(reference.registry, reference.repository, tag)
         } else {
-            Reference::with_digest(
+            Self::with_digest(
                 reference.registry,
                 reference.repository,
                 reference.digest.unwrap_or_default(),
@@ -476,7 +476,7 @@ impl From<OCIReference> for Reference {
         };
 
         if let Some(mirror) = reference.mirror_registry {
-            r.set_mirror_registry(mirror)
+            r.set_mirror_registry(mirror);
         }
 
         r
@@ -550,11 +550,12 @@ impl OCISettings {
         }
     }
 
+    #[must_use]
     pub fn to_client_config(&self) -> ClientConfig {
         let mut config = ClientConfig::default();
         if self.insecure {
             config.protocol = ClientProtocol::Http;
-        };
+        }
 
         if let Some(cert) = self.ca_file.as_ref() {
             config.extra_root_certificates.push(client::Certificate {
@@ -568,12 +569,13 @@ impl OCISettings {
         config
     }
 
+    #[must_use]
     pub fn to_auth(&self) -> RegistryAuth {
         let mut auth = RegistryAuth::Anonymous;
         if let Some(token) = self.token.as_ref() {
-            auth = RegistryAuth::Bearer(token.clone())
+            auth = RegistryAuth::Bearer(token.clone());
         } else if let Some(up) = self.regular.as_ref() {
-            auth = RegistryAuth::Basic(up.username.clone(), up.password.clone())
+            auth = RegistryAuth::Basic(up.username.clone(), up.password.clone());
         }
 
         auth
@@ -763,7 +765,7 @@ pub struct AdditionalLogs {
     /// file.
     ///
     /// Example config file:
-    /// additional_logs:
+    /// `additional_logs`:
     /// - name: test.txt
     ///   command: echo "hi"
     /// - name: test2.txt
@@ -988,6 +990,7 @@ impl TryFrom<&str> for GatherCommands {
 }
 
 impl GatherCommands {
+    #[must_use]
     pub fn new(mode: GatherMode, filter: Option<Filters>, settings: GatherSettings) -> Self {
         Self {
             mode,
@@ -1001,7 +1004,7 @@ impl GatherCommands {
     pub async fn load(&self) -> anyhow::Result<Config> {
         let env_secrets: Secrets = self.settings.secrets.clone().into();
         let mut secrets: Secrets = match self.settings.secrets_file.clone() {
-            Some(file) => file.clone().try_into()?,
+            Some(file) => file.try_into()?,
             None => vec![].into(),
         };
 
@@ -1027,16 +1030,11 @@ impl GatherCommands {
             systemd_units: self.settings.systemd_units.clone(),
             debug_pod: self.settings.debug_pod.clone(),
             disable_additional_logs: self.additional_logs.disable,
-            skip_logs_collection: self
-                .filter
-                .as_ref()
-                .map(|f| f.skip_logs_collection)
-                .unwrap_or_default(),
+            skip_logs_collection: self.filter.as_ref().is_some_and(|f| f.skip_logs_collection),
             skip_events_collection: self
                 .filter
                 .as_ref()
-                .map(|f| f.skip_events_collection)
-                .unwrap_or_default(),
+                .is_some_and(|f| f.skip_events_collection),
         })
     }
 
@@ -1046,8 +1044,8 @@ impl GatherCommands {
 }
 
 impl From<&GatherCommands> for FilterGroup {
-    fn from(val: &GatherCommands) -> FilterGroup {
-        FilterGroup(match &val.filter {
+    fn from(val: &GatherCommands) -> Self {
+        Self(match &val.filter {
             Some(filter) => vec![filter.into()],
             None => val.filters.iter().map(Into::into).collect(),
         })

--- a/src/filters/filter.rs
+++ b/src/filters/filter.rs
@@ -43,7 +43,7 @@ where
         let mut f = self
             .clone()
             .into_iter()
-            .flat_map(|f| f.filter_object(obj, gvk))
+            .filter_map(|f| f.filter_object(obj, gvk))
             .peekable();
 
         f.peek()?;
@@ -158,6 +158,7 @@ impl Serialize for FilterRegex {
 }
 
 impl FilterRegex {
+    #[must_use]
     pub fn matches(&self, s: &str) -> bool {
         self.0.is_match(s)
     }
@@ -271,7 +272,7 @@ mod tests {
         assert_eq!(
             FilterList(vec![]).filter_object(
                 &obj,
-                &GroupVersionKind::try_from(pod_tm.clone()).expect("parse GVK")
+                &GroupVersionKind::try_from(pod_tm).expect("parse GVK")
             ),
             Some(true)
         );
@@ -305,7 +306,7 @@ mod tests {
             Selector::<Exclude, Labels>::try_from("name=crust-gather").unwrap(),
         ])]);
 
-        let gvk = GroupVersionKind::try_from(pod_tm.clone()).expect("parse GVK");
+        let gvk = GroupVersionKind::try_from(pod_tm).expect("parse GVK");
         assert_eq!(filter.filter_object(&app_obj, &gvk), Some(false));
         assert_eq!(filter.filter_object(&name_obj, &gvk), Some(false));
     }

--- a/src/filters/group.rs
+++ b/src/filters/group.rs
@@ -20,6 +20,7 @@ pub struct GroupRegex {
 }
 
 impl GroupRegex {
+    #[must_use]
     pub fn matches(&self, gvk: &GroupVersionKind) -> bool {
         self.group.matches(&gvk.group) && self.kind.matches(&gvk.kind)
     }

--- a/src/gather/config.rs
+++ b/src/gather/config.rs
@@ -43,6 +43,7 @@ pub struct SecretsFile(pub PathBuf);
 
 impl Secrets {
     /// Replaces any secrets in representation data with xxx.
+    #[must_use]
     pub fn strip(&self, repr: &Representation) -> Representation {
         let mut data = repr.data().to_string();
         for secret in &self.0 {
@@ -163,7 +164,7 @@ impl KubeconfigFile {
     /// Creates a new Kubernetes client from the `KubeconfigFile`.
     pub async fn client(&self, insecure: bool) -> Result<Client, kube::Error> {
         let kubeconfig = match insecure {
-            true => KubeconfigFile::insecure(self.into()),
+            true => Self::insecure(self.into()),
             false => self.into(),
         };
 
@@ -173,7 +174,7 @@ impl KubeconfigFile {
     /// Creates a new Kubernetes client from the inferred config.
     pub async fn infer(insecure: bool) -> Result<Client, kube::Error> {
         let kubeconfig = match insecure {
-            true => KubeconfigFile::insecure(Kubeconfig::read()?),
+            true => Self::insecure(Kubeconfig::read()?),
             false => Kubeconfig::read()?,
         };
 
@@ -181,7 +182,7 @@ impl KubeconfigFile {
     }
 
     fn insecure(config: kube::config::Kubeconfig) -> kube::config::Kubeconfig {
-        let mut config = config.clone();
+        let mut config = config;
         Kubeconfig {
             clusters: config
                 .clusters
@@ -270,14 +271,12 @@ impl KubeconfigSecretNamespaceName {
             } => {
                 let api: Api<Secret> = Api::all(client);
                 SecretSearch(
-                    api.list(&ListParams {
-                        ..Default::default()
-                    })
-                    .await?
-                    .items
-                    .into_iter()
-                    .filter(|s| s.name_any() == name)
-                    .collect(),
+                    api.list(&ListParams::default())
+                        .await?
+                        .items
+                        .into_iter()
+                        .filter(|s| s.name_any() == name)
+                        .collect(),
                 )
             }
             NamespaceName { .. } => SecretSearch(vec![]),
@@ -296,6 +295,7 @@ impl From<String> for KubeconfigSecretNamespaceName {
 pub struct SecretSearch(Vec<Secret>);
 
 impl SecretSearch {
+    #[must_use]
     pub fn lookup<D: DeserializeOwned>(&self) -> Vec<D> {
         self.0
             .iter()
@@ -317,7 +317,7 @@ impl SecretSearch {
                 )
                 .ok()
             })
-            .filter_map(|v| BASE64_STANDARD.decode(v.replace("'", "").trim_end()).ok())
+            .filter_map(|v| BASE64_STANDARD.decode(v.replace('\'', "").trim_end()).ok())
             .filter_map(|v| String::from_utf8(v).ok())
             .find_map(|v| serde_saphyr::from_str(&v).ok())
     }
@@ -397,7 +397,7 @@ impl Config {
         };
         let collectables = discovery
             .groups()
-            .flat_map(|r| r.resources_by_stability())
+            .flat_map(kube::discovery::ApiGroup::resources_by_stability)
             .filter_map(|r| r.1.supports_operation(mode).then_some(r.0.into()))
             .flat_map(|group: Group| group.into_collectable(self.clone()));
 
@@ -408,7 +408,7 @@ impl Config {
                     self.duration.0.into(),
                     self.iterate_until_completion(collectables),
                 )
-                .await?
+                .await?;
             }
             GatherMode::Record => {
                 tracing::info!("Recording resources...");
@@ -501,13 +501,13 @@ impl Group {
                 }
             },
             GatherMode::Record => match self {
-                Group::Nodes(resource)
-                | Group::Pods(resource)
-                | Group::Events(resource)
-                | Group::Dynamic(resource) => {
+                Self::Nodes(resource)
+                | Self::Pods(resource)
+                | Self::Events(resource)
+                | Self::Dynamic(resource) => {
                     vec![
                         Collectable::Info(Info::new(gather.clone())),
-                        Collectable::WatchDynamic(Dynamic::new(gather.clone(), resource)),
+                        Collectable::WatchDynamic(Dynamic::new(gather, resource)),
                     ]
                 }
             },
@@ -613,12 +613,12 @@ mod tests {
             .await
             .expect("failed to create builder")
             .into(),
-            secrets: Default::default(),
+            secrets: Secrets::default(),
             mode: GatherMode::Collect,
             duration: "10s".try_into().unwrap(),
-            additional_logs: Default::default(),
-            systemd_units: Default::default(),
-            debug_pod: Default::default(),
+            additional_logs: Vec::default(),
+            systemd_units: Vec::default(),
+            debug_pod: DebugPod::default(),
             disable_additional_logs: false,
             skip_logs_collection: false,
             skip_events_collection: false,
@@ -627,7 +627,7 @@ mod tests {
         // Gzip archive is failing due to timeout.
         // As the archive can't be consumed, it can't be closed other way... (TODO)
         let result = config.collect().await;
-        assert!(result.is_err())
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -655,10 +655,10 @@ mod tests {
             .into(),
             duration: "1m".try_into().unwrap(),
             mode: GatherMode::Collect,
-            secrets: Default::default(),
-            additional_logs: Default::default(),
-            systemd_units: Default::default(),
-            debug_pod: Default::default(),
+            secrets: Secrets::default(),
+            additional_logs: Vec::default(),
+            systemd_units: Vec::default(),
+            debug_pod: DebugPod::default(),
             disable_additional_logs: false,
             skip_logs_collection: false,
             skip_events_collection: false,
@@ -693,10 +693,10 @@ mod tests {
             .into(),
             duration: "1m".try_into().unwrap(),
             mode: GatherMode::Collect,
-            secrets: Default::default(),
-            additional_logs: Default::default(),
-            systemd_units: Default::default(),
-            debug_pod: Default::default(),
+            secrets: Secrets::default(),
+            additional_logs: Vec::default(),
+            systemd_units: Vec::default(),
+            debug_pod: DebugPod::default(),
             disable_additional_logs: false,
             skip_logs_collection: false,
             skip_events_collection: false,

--- a/src/gather/printers.rs
+++ b/src/gather/printers.rs
@@ -34,6 +34,7 @@ pub struct ColumnDefinition {
 }
 
 impl ColumnDefinition {
+    #[must_use]
     pub fn json(name: &str, json_path: &str) -> Self {
         Self {
             source: CustomResourceColumnDefinition {
@@ -67,6 +68,7 @@ pub fn predefined_table(resource: &str) -> Option<Vec<TablePath>> {
     Some(columns.iter().map(TablePath::new).collect())
 }
 
+#[must_use]
 pub fn has_predefined_table(resource: &str) -> bool {
     predefined_tables().contains_key(resource)
 }
@@ -241,7 +243,7 @@ fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
                 ),
                 ColumnDefinition::cel(
                     "Duration",
-                    r#"!has(self.status.startTime) ? '0s' : age((has(self.status.completionTime) ? timestamp(self.status.completionTime) : now) - timestamp(self.status.startTime))"#,
+                    "!has(self.status.startTime) ? '0s' : age((has(self.status.completionTime) ? timestamp(self.status.completionTime) : now) - timestamp(self.status.startTime))",
                 ),
                 ColumnDefinition::cel("Age", AGE_CEL),
             ],
@@ -261,7 +263,7 @@ fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
                 ColumnDefinition::cel("Active", r#"self.get("status").get("active").or([]).size()"#),
                 ColumnDefinition::cel(
                     "Last Schedule",
-                    r#"has(self.status.lastScheduleTime) ? age(now - timestamp(self.status.lastScheduleTime)) : '<none>'"#,
+                    "has(self.status.lastScheduleTime) ? age(now - timestamp(self.status.lastScheduleTime)) : '<none>'",
                 ),
                 ColumnDefinition::cel("Age", AGE_CEL),
             ],
@@ -287,7 +289,7 @@ fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
                 ),
                 ColumnDefinition::cel(
                     "PORT(S)",
-                        r#"has(self.spec.ports)
+                        "has(self.spec.ports)
                             ? self.spec.ports
                                 .map(
                                     port,
@@ -297,7 +299,7 @@ fn predefined_tables() -> &'static BTreeMap<String, Vec<ColumnDefinition>> {
                                     + (has(port.protocol) ? port.protocol : 'TCP')
                                 )
                                 .join(',')
-                            : ''"#
+                            : ''"
                 ),
                 ColumnDefinition::cel("AGE", AGE_CEL),
             ],
@@ -503,6 +505,7 @@ impl TablePath {
         }
     }
 
+    #[must_use]
     pub fn to_definition(&self) -> serde_json::Value {
         let mut definition = serde_json::Map::from_iter([
             ("name".into(), json!(self.column.source.name)),
@@ -539,7 +542,7 @@ impl TablePath {
                 tracing::error!(
                     "failed to parse CEL for column {}: {cel}: {e}",
                     self.column.source.name
-                )
+                );
             })
             .ok()?;
         let mut context = Context::default();

--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -55,6 +55,7 @@ pub struct Destination {
 }
 
 impl Destination {
+    #[must_use]
     pub fn get_server(&self) -> &str {
         &self.server
     }
@@ -71,6 +72,7 @@ pub struct Get {
 }
 
 impl Get {
+    #[must_use]
     pub fn get_server(&self) -> &str {
         &self.server
     }
@@ -103,6 +105,7 @@ pub struct List {
 }
 
 impl List {
+    #[must_use]
     pub fn get_server(&self) -> &str {
         &self.server
     }
@@ -117,6 +120,7 @@ pub struct ObjectValueList {
 }
 
 impl ObjectValueList {
+    #[must_use]
     pub fn new(list: NamedObject, items: Vec<DynamicObject>) -> Self {
         Self {
             type_meta: TypeMeta {
@@ -147,7 +151,7 @@ impl Table {
     ) -> anyhow::Result<Self> {
         let mut data = vec![];
 
-        data.extend(Table::table_entries(storage, crd_path, list).await?);
+        data.extend(Self::table_entries(storage, crd_path, list).await?);
         let items: anyhow::Result<Vec<serde_json::Value>> = items
             .into_iter()
             .map(|i| serde_json::to_value(i).map_err(Into::into))
@@ -186,7 +190,7 @@ impl Table {
                     },
                     ..Default::default()
                 },
-                None => Default::default(),
+                None => CustomResourceDefinition::default(),
             },
         };
 
@@ -245,7 +249,7 @@ impl Table {
     }
 
     fn to_row(&self, obj: impl Serialize) -> anyhow::Result<serde_json::Value> {
-        let Table { data: rows, .. } = self;
+        let Self { data: rows, .. } = self;
         let obj = serde_json::to_value(obj)?;
         let cells: Vec<serde_json::Value> = rows
             .iter()
@@ -259,11 +263,14 @@ impl Table {
     }
 
     fn definitions(&self) -> Vec<serde_json::Value> {
-        self.data.iter().map(|r| r.to_definition()).collect()
+        self.data
+            .iter()
+            .map(super::printers::TablePath::to_definition)
+            .collect()
     }
 
     fn rows(&self) -> anyhow::Result<Vec<serde_json::Value>> {
-        let Table { items, .. } = self;
+        let Self { items, .. } = self;
         items.iter().map(|i| self.to_row(i)).collect()
     }
 
@@ -314,7 +321,7 @@ trait GatherObject: ResourceExt + Sized + Serialize {
                 serde_json::from_str(&format!("\"{last_sync_timestamp}\"")).ok()
             }
             // Handling of pre-record feature versions
-            None => Some(Default::default()),
+            None => Some(DateTime::default()),
         }
     }
 
@@ -370,13 +377,18 @@ impl NamedResource {
 struct NamedResourcesState<'a> {
     archive: Archive,
     storage: &'a Storage,
+    served_crs_only: bool,
 }
 
 type DiscoveryResource = (String, String, APIResourceDiscovery);
 
 impl<'a> NamedResourcesState<'a> {
-    fn new(archive: Archive, storage: &'a Storage) -> Self {
-        Self { archive, storage }
+    const fn new(archive: Archive, storage: &'a Storage, served_crs_only: bool) -> Self {
+        Self {
+            archive,
+            storage,
+            served_crs_only,
+        }
     }
 
     async fn discovery_file(&self, path: ArchivePath) -> anyhow::Result<Vec<DiscoveryResource>> {
@@ -463,13 +475,17 @@ impl<'a> NamedResourcesState<'a> {
             singular: resource
                 .singular_resource
                 .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| kind.to_string().to_lowercase()),
+                .unwrap_or_else(|| kind.clone().to_lowercase()),
         };
 
-        self.filter_crd_resource(resource).await
+        if !self.served_crs_only {
+            return Some(resource)
+        }
+        
+        self.only_served_stored_resource(resource).await
     }
 
-    async fn filter_crd_resource(&self, resource: NamedResource) -> Option<NamedResource> {
+    async fn only_served_stored_resource(&self, resource: NamedResource) -> Option<NamedResource> {
         let Some(crd_path) = resource.get_crd_path() else {
             return Some(resource);
         };
@@ -543,14 +559,17 @@ pub struct NamedObject {
 }
 
 impl NamedObject {
+    #[must_use]
     pub fn get_path(&self) -> ArchivePath {
         ArchivePath::new_path(self, self.to_type_meta())
     }
 
+    #[must_use]
     pub fn get_crd_path(&self) -> Option<ArchivePath> {
         self.named_resource.get_crd_path()
     }
 
+    #[must_use]
     pub fn get_logs_path(&self, log: &Log) -> ArchivePath {
         ArchivePath::new_logs(
             self,
@@ -596,8 +615,13 @@ pub struct ArchiveReader {
 }
 
 impl ArchiveReader {
-    pub async fn new(archive: Archive, storage: &Storage, buffer_size: usize) -> Self {
-        let state = NamedResourcesState::new(archive.clone(), storage);
+    pub async fn new(
+        archive: Archive,
+        storage: &Storage,
+        buffer_size: usize,
+        served_crs_only: bool,
+    ) -> Self {
+        let state = NamedResourcesState::new(archive.clone(), storage, served_crs_only);
         let mut named_resources = NamedResources::default();
 
         match state
@@ -618,7 +642,7 @@ impl ArchiveReader {
             Err(e) => {
                 tracing::error!("Fail parsing api.json : {e:?}");
             }
-        };
+        }
 
         Self {
             archive,
@@ -627,11 +651,13 @@ impl ArchiveReader {
         }
     }
 
+    #[must_use]
     pub fn join(&self, path: ArchivePath) -> PathBuf {
         self.archive.join(path)
     }
 
     /// Returns the archive's root path. Used to distinguish archives in hash/eq.
+    #[must_use]
     pub fn path(&self) -> PathBuf {
         self.archive.path()
     }
@@ -718,7 +744,7 @@ impl Reader {
                 let record_timestamp: DateTime<Utc> = serde_json::from_slice(&file)?;
                 beginning.signed_duration_since(record_timestamp).to_std()?
             }
-            false => Default::default(),
+            false => Duration::default(),
         };
         Ok(Self {
             archive,
@@ -742,6 +768,7 @@ impl Reader {
         Utc::now() - self.diff
     }
 
+    #[must_use]
     pub fn pop_next_event_time(&self) -> Duration {
         let mut next_patch_time = self
             .next_patch_time
@@ -785,7 +812,7 @@ impl Reader {
             let event = object
                 .table_watch_event(crd_path, list.clone(), &self.storage)
                 .await?;
-            events.push(event)
+            events.push(event);
         }
 
         Ok(events)
@@ -803,7 +830,7 @@ impl Reader {
         self.objects(list.get_path())
             .await?
             .filter(|obj| selector.matches(obj.labels()))
-            .map(|obj| obj.watch_event())
+            .map(GatherObject::watch_event)
             .map(|ev| serde_json::to_value(ev).map_err(Into::into))
             .collect()
     }
@@ -855,7 +882,7 @@ impl Reader {
                         items.push(version);
                     }
                 }
-            };
+            }
         }
 
         {
@@ -957,7 +984,7 @@ impl Reader {
                         self.interpolate(
                             &original,
                             path.with_extension("patch"),
-                            Default::default(),
+                            DateTime::default(),
                             self.archive_time(),
                         )
                         .await?,
@@ -1009,17 +1036,16 @@ impl Reader {
                             return Ok(versions);
                         } else if last_sync_timestamp <= from {
                             break;
-                        } else {
-                            do_apply = true;
                         }
+                        do_apply = true;
                     }
                     _ => (),
-                };
+                }
             }
 
             if do_apply && !patches.is_empty() {
                 patch(&mut target, &patches)?;
-                versions.push(serde_json::from_value(target.clone())?)
+                versions.push(serde_json::from_value(target.clone())?);
             }
         }
 

--- a/src/gather/reader.rs
+++ b/src/gather/reader.rs
@@ -356,59 +356,91 @@ struct NamedResource {
     list_kind: String,
 }
 
-#[derive(Clone, Debug, Default)]
-struct NamedResources(HashMap<GroupVersionResource, NamedResource>);
+impl NamedResource {
+    pub fn get_crd_path(&self) -> Option<ArchivePath> {
+        self.group.as_ref().map(|group| {
+            ArchivePath::new_path(
+                NamespaceName::new(Some(format!("{}.{}", self.resource, group)), None),
+                TypeMeta::resource::<CustomResourceDefinition>(),
+            )
+        })
+    }
+}
 
-impl NamedResources {
-    async fn from_discovery_file(path: PathBuf, storage: &Storage) -> anyhow::Result<Self> {
+struct NamedResourcesState<'a> {
+    archive: Archive,
+    storage: &'a Storage,
+}
+
+type DiscoveryResource = (String, String, APIResourceDiscovery);
+
+impl<'a> NamedResourcesState<'a> {
+    fn new(archive: Archive, storage: &'a Storage) -> Self {
+        Self { archive, storage }
+    }
+
+    async fn discovery_file(&self, path: ArchivePath) -> anyhow::Result<Vec<DiscoveryResource>> {
         let mut object = vec![];
-        storage.read(path.clone(), &mut object).await?;
+        self.storage
+            .read(self.archive.join(path), &mut object)
+            .await?;
 
         let discovery = serde_saphyr::from_slice(&object)?;
-        Ok(Self::from_discovery_groups(discovery))
+        Ok(self.discovery_groups(discovery))
     }
 
-    fn from_discovery_groups(groups: APIGroupDiscoveryList) -> Self {
-        let mut resources = Self::default();
-
-        for api_group in groups.items {
-            resources.insert_group(api_group);
-        }
-
-        resources
+    fn discovery_groups(&self, groups: APIGroupDiscoveryList) -> Vec<DiscoveryResource> {
+        groups
+            .items
+            .into_iter()
+            .flat_map(|group| self.process_group(group))
+            .collect()
     }
 
-    fn insert_group(&mut self, api_group: APIGroupDiscovery) -> Option<()> {
-        self.insert_discovery_versions(
-            &api_group.metadata?.name.unwrap_or_default(),
-            api_group.versions,
-        );
-        Some(())
+    fn process_group(&self, api_group: APIGroupDiscovery) -> Vec<DiscoveryResource> {
+        let Some(metadata) = api_group.metadata else {
+            return Vec::new();
+        };
+        let group = metadata.name.unwrap_or_default();
+        self.process_discovery_versions(group, api_group.versions)
     }
 
-    fn insert_discovery_versions(&mut self, group: &str, versions: Vec<APIVersionDiscovery>) {
-        for api_version in versions {
-            self.insert_version(group, api_version);
-        }
+    fn process_discovery_versions(
+        &self,
+        group: String,
+        versions: Vec<APIVersionDiscovery>,
+    ) -> Vec<DiscoveryResource> {
+        versions
+            .into_iter()
+            .flat_map(|version| self.process_version(&group, version))
+            .collect()
     }
 
-    fn insert_version(&mut self, group: &str, api_version: APIVersionDiscovery) -> Option<()> {
-        self.insert_discovery_resources(group, &api_version.version?, api_version.resources);
-        Some(())
-    }
-
-    fn insert_discovery_resources(
-        &mut self,
+    fn process_version(
+        &self,
         group: &str,
-        version: &str,
-        resources: Vec<APIResourceDiscovery>,
-    ) {
-        for res in resources {
-            self.insert_resource(group, version, res);
-        }
+        api_version: APIVersionDiscovery,
+    ) -> Vec<DiscoveryResource> {
+        let Some(version) = api_version.version else {
+            return Vec::new();
+        };
+        self.process_discovery_resources(group, version, api_version.resources)
     }
 
-    fn parse_discovery_resource(
+    fn process_discovery_resources(
+        &self,
+        group: &str,
+        version: String,
+        resources: Vec<APIResourceDiscovery>,
+    ) -> Vec<DiscoveryResource> {
+        resources
+            .into_iter()
+            .map(|resource| (group.to_owned(), version.clone(), resource))
+            .collect()
+    }
+
+    async fn parse_discovery_resource(
+        &self,
         group: &str,
         version: &str,
         resource: APIResourceDiscovery,
@@ -416,7 +448,7 @@ impl NamedResources {
         let gvk = resource.response_kind?;
         let kind = gvk.kind?;
 
-        Some(NamedResource {
+        let resource = NamedResource {
             group: gvk
                 .group
                 .filter(|g| !g.is_empty())
@@ -432,27 +464,67 @@ impl NamedResources {
                 .singular_resource
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| kind.to_string().to_lowercase()),
-        })
+        };
+
+        self.filter_crd_resource(resource).await
     }
 
+    async fn filter_crd_resource(&self, resource: NamedResource) -> Option<NamedResource> {
+        let Some(crd_path) = resource.get_crd_path() else {
+            return Some(resource);
+        };
+
+        let crd_path = self.archive.join(crd_path);
+        if !self.storage.exist(&crd_path) {
+            return Some(resource);
+        }
+
+        let crd: CustomResourceDefinition = {
+            let mut file = vec![];
+            self.storage.read(crd_path, &mut file).await.ok()?;
+            serde_saphyr::from_slice(&file).ok()?
+        };
+
+        crd.spec
+            .versions
+            .iter()
+            .find(|crd| crd.name == resource.version && crd.served && crd.storage)?;
+
+        Some(resource)
+    }
+}
+
+#[derive(Clone, Default)]
+struct NamedResources {
+    resources: HashMap<GroupVersionResource, NamedResource>,
+}
+
+impl NamedResources {
     fn get(&self, gvr: &GroupVersionResource) -> Option<&NamedResource> {
-        self.0.get(gvr)
+        self.resources.get(gvr)
     }
 
-    fn extend(&mut self, other: NamedResources) {
-        self.0.extend(other.0);
-    }
-
-    fn insert_resource(
+    async fn insert_resources(
         &mut self,
+        state: &NamedResourcesState<'_>,
+        resources: Vec<DiscoveryResource>,
+    ) {
+        for (group, version, resource) in resources {
+            self.insert_resource(state, &group, &version, resource)
+                .await;
+        }
+    }
+
+    async fn insert_resource(
+        &mut self,
+        state: &NamedResourcesState<'_>,
         group: &str,
         version: &str,
         res: APIResourceDiscovery,
     ) -> Option<NamedResource> {
-        let res = Self::parse_discovery_resource(group, version, res)?;
-        tracing::debug!("{res:?}");
+        let res = state.parse_discovery_resource(group, version, res).await?;
 
-        self.0.insert(
+        self.resources.insert(
             GroupVersionResource::gvr(
                 res.group.as_deref().unwrap_or_default(),
                 &res.version,
@@ -476,15 +548,7 @@ impl NamedObject {
     }
 
     pub fn get_crd_path(&self) -> Option<ArchivePath> {
-        self.named_resource.group.as_ref().map(|group| {
-            ArchivePath::new_path(
-                NamespaceName::new(
-                    Some(format!("{}.{}", self.named_resource.resource, group)),
-                    None,
-                ),
-                TypeMeta::resource::<CustomResourceDefinition>(),
-            )
-        })
+        self.named_resource.get_crd_path()
     }
 
     pub fn get_logs_path(&self, log: &Log) -> ArchivePath {
@@ -533,26 +597,24 @@ pub struct ArchiveReader {
 
 impl ArchiveReader {
     pub async fn new(archive: Archive, storage: &Storage, buffer_size: usize) -> Self {
-        let mut named_resources = match NamedResources::from_discovery_file(
-            archive.join(ArchivePath::Custom("apis.json".into())),
-            storage,
-        )
-        .await
+        let state = NamedResourcesState::new(archive.clone(), storage);
+        let mut named_resources = NamedResources::default();
+
+        match state
+            .discovery_file(ArchivePath::Custom("apis.json".into()))
+            .await
         {
-            Ok(named_resources) => named_resources,
+            Ok(resources) => named_resources.insert_resources(&state, resources).await,
             Err(e) => {
                 tracing::error!("Fail parsing apis.json : {e:?}");
-                NamedResources::default()
             }
-        };
+        }
 
-        match NamedResources::from_discovery_file(
-            archive.join(ArchivePath::Custom("api.json".into())),
-            storage,
-        )
-        .await
+        match state
+            .discovery_file(ArchivePath::Custom("api.json".into()))
+            .await
         {
-            Ok(nrs) => named_resources.extend(nrs),
+            Ok(resources) => named_resources.insert_resources(&state, resources).await,
             Err(e) => {
                 tracing::error!("Fail parsing api.json : {e:?}");
             }

--- a/src/gather/representation.rs
+++ b/src/gather/representation.rs
@@ -35,16 +35,17 @@ impl NamespacedName for NamespaceName {
 
 impl NamespacedName for &ObjectMeta {
     fn name(&self) -> Option<String> {
-        self.name.to_owned()
+        self.name.clone()
     }
 
     fn namespace(&self) -> Option<String> {
-        self.namespace.to_owned()
+        self.namespace.clone()
     }
 }
 
 impl NamespaceName {
-    pub fn new(name: Option<String>, namespace: Option<String>) -> Self {
+    #[must_use]
+    pub const fn new(name: Option<String>, namespace: Option<String>) -> Self {
         Self { name, namespace }
     }
 }
@@ -52,10 +53,10 @@ impl NamespaceName {
 impl From<String> for NamespaceName {
     fn from(value: String) -> Self {
         match value.split_once('/') {
-            Some(("", name)) => NamespaceName::new(Some(name.into()), None),
-            Some((ns, "")) => NamespaceName::new(None, Some(ns.into())),
-            Some((ns, name)) => NamespaceName::new(Some(name.into()), Some(ns.into())),
-            None => NamespaceName::new(Some(value), None),
+            Some(("", name)) => Self::new(Some(name.into()), None),
+            Some((ns, "")) => Self::new(None, Some(ns.into())),
+            Some((ns, name)) => Self::new(Some(name.into()), Some(ns.into())),
+            None => Self::new(Some(value), None),
         }
     }
 }
@@ -139,7 +140,7 @@ impl ArchivePath {
     }
 
     pub fn to_path<R: ResourceThreadSafe>(resource: &R, type_meta: TypeMeta) -> Self {
-        ArchivePath::new_path(resource.meta(), type_meta)
+        Self::new_path(resource.meta(), type_meta)
     }
 
     pub fn new_path(namespace_name: impl NamespacedName, type_meta: TypeMeta) -> Self {
@@ -149,18 +150,16 @@ impl ArchivePath {
         );
 
         match (namespace_name.name(), namespace_name.namespace()) {
-            (Some(name), Some(namespace)) => ArchivePath::Namespaced(
+            (Some(name), Some(namespace)) => Self::Namespaced(
                 format!("namespaces/{namespace}/{api_version}/{kind}/{name}.yaml").into(),
             ),
             (Some(name), None) => {
-                ArchivePath::Cluster(format!("cluster/{api_version}/{kind}/{name}.yaml").into())
+                Self::Cluster(format!("cluster/{api_version}/{kind}/{name}.yaml").into())
             }
-            (None, Some(namespace)) => ArchivePath::NamespacedList(
+            (None, Some(namespace)) => Self::NamespacedList(
                 format!("namespaces/{namespace}/{api_version}/{kind}/*.yaml").into(),
             ),
-            (None, None) => {
-                ArchivePath::ClusterList(format!("**/{api_version}/{kind}/*.yaml").into())
-            }
+            (None, None) => Self::ClusterList(format!("**/{api_version}/{kind}/*.yaml").into()),
         }
     }
 
@@ -169,13 +168,13 @@ impl ArchivePath {
         type_meta: TypeMeta,
         logs: LogGroup,
     ) -> Self {
-        match ArchivePath::new_path(namespace_name, type_meta) {
-            ArchivePath::Namespaced(path) | ArchivePath::Cluster(path) => match logs {
+        match Self::new_path(namespace_name, type_meta) {
+            Self::Namespaced(path) | Self::Cluster(path) => match logs {
                 LogGroup::Current(Container(container)) => {
-                    ArchivePath::Logs(path.with_extension("").join(container).join("current.log"))
+                    Self::Logs(path.with_extension("").join(container).join("current.log"))
                 }
                 LogGroup::Previous(Container(container)) => {
-                    ArchivePath::Logs(path.with_extension("").join(container).join("previous.log"))
+                    Self::Logs(path.with_extension("").join(container).join("previous.log"))
                 }
             },
             other => other,
@@ -187,18 +186,19 @@ impl ArchivePath {
         type_meta: TypeMeta,
         logs: LogGroup,
     ) -> Self {
-        ArchivePath::new_logs(resource.meta(), type_meta, logs)
+        Self::new_logs(resource.meta(), type_meta, logs)
     }
 
+    #[must_use]
     pub fn parent(&self) -> Option<&Path> {
         match self {
-            ArchivePath::Empty => None,
-            ArchivePath::Cluster(path) => path.parent(),
-            ArchivePath::Namespaced(path) => path.parent(),
-            ArchivePath::Logs(path) => path.parent(),
-            ArchivePath::Custom(path) => path.parent(),
-            ArchivePath::NamespacedList(path) => Some(path.as_path()),
-            ArchivePath::ClusterList(path) => Some(path.as_path()),
+            Self::Empty => None,
+            Self::Cluster(path) => path.parent(),
+            Self::Namespaced(path) => path.parent(),
+            Self::Logs(path) => path.parent(),
+            Self::Custom(path) => path.parent(),
+            Self::NamespacedList(path) => Some(path.as_path()),
+            Self::ClusterList(path) => Some(path.as_path()),
         }
     }
 }
@@ -206,13 +206,13 @@ impl ArchivePath {
 impl Display for ArchivePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArchivePath::Empty => write!(f, "<empty>"),
-            ArchivePath::Cluster(path) => write!(f, "{}", path.display()),
-            ArchivePath::Namespaced(path) => write!(f, "{}", path.display()),
-            ArchivePath::Logs(path) => write!(f, "{}", path.display()),
-            ArchivePath::Custom(path) => write!(f, "{}", path.display()),
-            ArchivePath::NamespacedList(path) => write!(f, "{}", path.display()),
-            ArchivePath::ClusterList(path) => write!(f, "{}", path.display()),
+            Self::Empty => write!(f, "<empty>"),
+            Self::Cluster(path) => write!(f, "{}", path.display()),
+            Self::Namespaced(path) => write!(f, "{}", path.display()),
+            Self::Logs(path) => write!(f, "{}", path.display()),
+            Self::Custom(path) => write!(f, "{}", path.display()),
+            Self::NamespacedList(path) => write!(f, "{}", path.display()),
+            Self::ClusterList(path) => write!(f, "{}", path.display()),
         }
     }
 }
@@ -239,7 +239,7 @@ impl TryFrom<ArchivePath> for String {
 impl From<ArchivePath> for PathBuf {
     fn from(value: ArchivePath) -> Self {
         match value {
-            ArchivePath::Empty => PathBuf::new(),
+            ArchivePath::Empty => Self::new(),
             ArchivePath::Cluster(path) => path,
             ArchivePath::Namespaced(path) => path,
             ArchivePath::NamespacedList(path) => path,
@@ -258,10 +258,12 @@ pub struct Representation {
 }
 
 impl Representation {
+    #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        Representation::default()
     }
 
+    #[must_use]
     pub fn with_data(self, data: &str) -> Self {
         Self {
             data: data.into(),
@@ -269,18 +271,22 @@ impl Representation {
         }
     }
 
+    #[must_use]
     pub fn with_path(self, path: ArchivePath) -> Self {
         Self { path, ..self }
     }
 
+    #[must_use]
     pub fn data(&self) -> &str {
         self.data.as_ref()
     }
 
+    #[must_use]
     pub fn path(&self) -> ArchivePath {
         self.path.clone()
     }
 
+    #[must_use]
     pub fn load_data(&self) -> Self {
         self.clone()
     }

--- a/src/gather/selector.rs
+++ b/src/gather/selector.rs
@@ -14,14 +14,13 @@ pub struct Selector {
 }
 
 impl Selector {
+    #[must_use]
     pub fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
         let Some(selector) = self.label_selector.as_deref() else {
             return true;
         };
 
-        Expressions::try_from(selector)
-            .map(|expr| expr.matches(labels))
-            .unwrap_or_default()
+        Expressions::try_from(selector).is_ok_and(|expr| expr.matches(labels))
     }
 }
 
@@ -39,6 +38,7 @@ impl schemars::JsonSchema for Expressions {
 }
 
 impl Expressions {
+    #[must_use]
     pub fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
         self.deref().clone().into_iter().all(|expression| {
             match expression.deref().clone() {
@@ -59,6 +59,6 @@ impl TryFrom<&str> for Expressions {
 
     #[instrument(err)]
     fn try_from(selector: &str) -> unselector::Result<Self> {
-        Ok(Expressions(selector.try_into()?))
+        Ok(Self(selector.try_into()?))
     }
 }

--- a/src/gather/server.rs
+++ b/src/gather/server.rs
@@ -1,6 +1,6 @@
 use std::{
-    collections::HashMap, fmt::Display, fs::File, future::pending, net::SocketAddr, ops::Deref,
-    path::PathBuf, str::FromStr, sync::Arc, time::Duration,
+    collections::HashMap, fmt::Display, fs::File, net::SocketAddr, ops::Deref, path::PathBuf,
+    str::FromStr, sync::Arc, time::Duration,
 };
 
 use actix_web::{
@@ -106,6 +106,12 @@ pub struct Server {
         value_parser = |arg: &str| -> anyhow::Result<Socket> {Socket::try_from(arg)})]
     #[serde(default)]
     socket: Socket,
+
+    /// Only serve custom resource versions marked as both served and storage
+    /// in the archived CRD.
+    #[arg(long)]
+    #[serde(default)]
+    served_crs_only: bool,
 }
 
 impl Server {
@@ -116,10 +122,17 @@ impl Server {
                 self.oci.clone(),
                 self.socket.clone(),
                 self.kubeconfig.clone(),
+                self.served_crs_only,
             )
             .await
         } else {
-            Api::new(archives, self.socket.clone(), self.kubeconfig.clone()).await
+            Api::new(
+                archives,
+                self.socket.clone(),
+                self.kubeconfig.clone(),
+                self.served_crs_only,
+            )
+            .await
         }
     }
 }
@@ -151,12 +164,13 @@ impl Api {
         archives: impl IntoIterator<Item = Archive> + Clone,
         socket: Socket,
         kubeconfig: Option<PathBuf>,
+        served_crs_only: bool,
     ) -> anyhow::Result<Self> {
         let Socket(socket) = socket;
 
         let kubeconfig_path = kubeconfig.unwrap_or(std::path::PathBuf::from(
             std::env::var("KUBECONFIG")
-                .unwrap_or(format!("{}/.kube/config", std::env::var("HOME")?).to_string()),
+                .unwrap_or(format!("{}/.kube/config", std::env::var("HOME")?)),
         ));
 
         let mut config = match File::open(&kubeconfig_path) {
@@ -170,7 +184,7 @@ impl Api {
         let config = archives
             .clone()
             .into_iter()
-            .map(|a| Api::prepare_kubeconfig(a.name().to_string_lossy().to_string(), socket))
+            .map(|a| Self::prepare_kubeconfig(a.name().to_string_lossy().to_string(), socket))
             .try_fold(config, Kubeconfig::merge)?;
 
         serde_saphyr::to_io_writer(&mut File::create(&kubeconfig_path)?, &config)?;
@@ -178,8 +192,14 @@ impl Api {
         let mut readers = HashMap::new();
         for archive in archives {
             readers.insert(
-                Api::convert_name(archive.name().to_string_lossy().to_string()),
-                ArchiveReader::new(archive, &Storage::FS, DEFAULT_OCI_BUFFER_SIZE).await,
+                Self::convert_name(archive.name().to_string_lossy().to_string()),
+                ArchiveReader::new(
+                    archive,
+                    &Storage::FS,
+                    DEFAULT_OCI_BUFFER_SIZE,
+                    served_crs_only,
+                )
+                .await,
             );
         }
 
@@ -199,6 +219,7 @@ impl Api {
         oci: OCISettings,
         socket: Socket,
         kubeconfig: Option<PathBuf>,
+        served_crs_only: bool,
     ) -> anyhow::Result<Self> {
         let Some(reference) = &oci.reference else {
             anyhow::bail!("missing reference");
@@ -210,7 +231,7 @@ impl Api {
 
         let kubeconfig_path = kubeconfig.unwrap_or(std::path::PathBuf::from(
             std::env::var("KUBECONFIG")
-                .unwrap_or(format!("{}/.kube/config", std::env::var("HOME")?).to_string()),
+                .unwrap_or(format!("{}/.kube/config", std::env::var("HOME")?)),
         ));
 
         let mut config = match File::open(&kubeconfig_path) {
@@ -221,7 +242,7 @@ impl Api {
         let previous_context = config.current_context;
         config.current_context = None;
 
-        let config = config.merge(Api::prepare_kubeconfig(
+        let config = config.merge(Self::prepare_kubeconfig(
             reference.repository().to_string(),
             socket,
         ))?;
@@ -246,8 +267,14 @@ impl Api {
         let search = ArchiveSearch::default();
         let mut archives = HashMap::new();
         archives.insert(
-            Api::convert_name(reference.repository().to_string()),
-            ArchiveReader::new(Archive::new(search.path()), &storage, oci.buffer_size).await,
+            Self::convert_name(reference.repository().to_string()),
+            ArchiveReader::new(
+                Archive::new(search.path()),
+                &storage,
+                oci.buffer_size,
+                served_crs_only,
+            )
+            .await,
         );
 
         Ok(Self {
@@ -274,7 +301,9 @@ impl Api {
             let Some(annotations) = layer.annotations.clone() else {
                 anyhow::bail!("manifest layer contains no org.opencontainers.image.title annoation")
             };
-            let path = &annotations["org.opencontainers.image.title"];
+            let path = annotations
+                .get("org.opencontainers.image.title")
+                .ok_or(anyhow::anyhow!("missing org.opencontainers.image title"))?;
             index.insert(PathBuf::from(path), Descriptor::OciDescriptor(layer));
         }
 
@@ -282,7 +311,7 @@ impl Api {
             return Ok(index);
         };
 
-        let data = pull_blob_cached(client, reference, auth, index_layer.deref(), true).await?;
+        let data = pull_blob_cached(client, reference, auth, index_layer, true).await?;
         let resource_paths: Vec<YamlPath> = serde_saphyr::from_slice(&data)?;
         for yaml_path in resource_paths {
             let resource_path = yaml_path.path;
@@ -312,7 +341,7 @@ impl Api {
     }
 
     fn prepare_kubeconfig(name: String, socket: SocketAddr) -> Kubeconfig {
-        let name = Api::convert_name(name);
+        let name = Self::convert_name(name);
         Kubeconfig {
             current_context: Some(name.clone()),
             auth_infos: vec![NamedAuthInfo {
@@ -659,13 +688,11 @@ async fn list_response(
     query: Query<Selector>,
     state: web::Data<ApiState>,
 ) -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok()
-        .content_type("application/json")
-        .body(serde_json::to_string(
-            &list_items(accept, list, query, state)
-                .await
-                .map_err(error::ErrorNotFound)?,
-        )?))
+    Ok(HttpResponse::Ok().json(
+        &list_items(accept, list, query, state)
+            .await
+            .map_err(error::ErrorNotFound)?,
+    ))
 }
 
 // Streaming responder with watch events
@@ -697,7 +724,7 @@ async fn watch_response(
                 !bookmark_published {
                 let event = bookmark_event(list.to_type_meta());
                 yield publish(serde_json::to_value(event)?);
-                bookmark_published = true
+                bookmark_published = true;
             }
 
             for event in watch_events(accept.clone(), list.clone(), query.clone(), &reader).await? {
@@ -779,7 +806,7 @@ async fn logs_get(
         .named_object_from_get(get.clone())
         .map_err(error::ErrorNotFound)?;
     let mut body = reader
-        .load_raw(get.get_logs_path(query.deref()))
+        .load_raw(get.get_logs_path(&query))
         .await
         .map_err(error::ErrorBadRequest)?;
 
@@ -801,17 +828,10 @@ async fn logs_get(
         );
     }
 
-    actix_web::rt::spawn(async move {
-        if session
-            .text(BASE64_STANDARD.encode(body.as_bytes()))
-            .await
-            .is_err()
-        {
-            return;
-        }
-
-        pending::<()>().await;
-    });
+    session
+        .text(BASE64_STANDARD.encode(body.as_bytes()))
+        .await
+        .map_err(error::ErrorBadRequest)?;
 
     Ok(response)
 }
@@ -835,7 +855,7 @@ fn prefix_log_timestamps(logs: &str, serve_time: DateTime<Utc>, timestamped: boo
         return logs.to_string();
     };
 
-    let Some((timestamp, _)) = line.split_once(" ") else {
+    let Some((timestamp, _)) = line.split_once(' ') else {
         return logs.to_string();
     };
 
@@ -848,7 +868,7 @@ fn prefix_log_timestamps(logs: &str, serve_time: DateTime<Utc>, timestamped: boo
         Box::new(|line| format!("{timestamp} {line}"))
     } else {
         Box::new(|line| {
-            let Some((_, line)) = line.split_once(" ") else {
+            let Some((_, line)) = line.split_once(' ') else {
                 return line.to_string();
             };
             line.to_string()
@@ -865,4 +885,20 @@ async fn get_item(get: Path<Get>, state: web::Data<ApiState>) -> anyhow::Result<
     let reader = state.to_reader(archive.clone()).await?;
     let get = archive.named_object_from_get(get.clone())?;
     reader.load(get).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn served_crs_only_is_opt_in() {
+        assert!(!Server::default().served_crs_only);
+        assert!(!Server::try_parse_from(["serve"]).unwrap().served_crs_only);
+        assert!(
+            Server::try_parse_from(["serve", "--served-crs-only"])
+                .unwrap()
+                .served_crs_only
+        );
+    }
 }

--- a/src/gather/storage.rs
+++ b/src/gather/storage.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap, fs::File, io::Read as _, ops::Deref as _, path::PathBuf, pin::pin,
-    sync::Arc,
-};
+use std::{collections::HashMap, fs::File, io::Read as _, path::PathBuf, pin::pin, sync::Arc};
 
 use anyhow::bail;
 use base64::{Engine as _, prelude::BASE64_STANDARD};
@@ -35,42 +32,44 @@ pub enum Descriptor {
 }
 
 impl Storage {
+    #[must_use]
     pub fn new(oci: Option<OCIState>) -> Self {
         match oci {
-            Some(oci) => Storage::OCI(Box::new(oci)),
-            None => Storage::FS,
+            Some(oci) => Self::OCI(Box::new(oci)),
+            None => Self::FS,
         }
     }
 
     pub async fn read_raw(&self, path: PathBuf) -> anyhow::Result<String> {
         match self {
-            Storage::FS => {
+            Self::FS => {
                 let mut file = File::open(path)?;
                 let mut data = String::new();
                 File::read_to_string(&mut file, &mut data)?;
                 Ok(data)
             }
-            Storage::OCI(oci_state) => Ok(oci_state.read_raw(path).await?),
+            Self::OCI(oci_state) => Ok(oci_state.read_raw(path).await?),
         }
     }
 
     pub async fn read<W: AsyncWrite>(&self, path: PathBuf, out: W) -> anyhow::Result<usize> {
         match self {
-            Storage::FS => {
+            Self::FS => {
                 let mut file = File::open(path)?;
                 let mut data = String::new();
                 File::read_to_string(&mut file, &mut data)?;
                 let mut out = pin!(out);
                 Ok(out.write(data.as_bytes()).await?)
             }
-            Storage::OCI(oci_state) => Ok(oci_state.read(path, out).await?),
+            Self::OCI(oci_state) => Ok(oci_state.read(path, out).await?),
         }
     }
 
+    #[must_use]
     pub fn exist(&self, path: &PathBuf) -> bool {
         match self {
-            Storage::FS => path.exists(),
-            Storage::OCI(ocistate) => ocistate.index.contains_key(path),
+            Self::FS => path.exists(),
+            Self::OCI(ocistate) => ocistate.index.contains_key(path),
         }
     }
 
@@ -80,12 +79,12 @@ impl Storage {
             .to_str()
             .map_or_else(|| bail!("Unable to convert path to string: {path:?}"), Ok)?;
         match self {
-            Storage::FS => {
+            Self::FS => {
                 for path in glob::glob(path)? {
                     paths.push(path?);
                 }
             }
-            Storage::OCI(ocistate) => {
+            Self::OCI(ocistate) => {
                 let pattern = glob::Pattern::new(path)?;
                 for path in ocistate.index.keys() {
                     if pattern.matches(
@@ -98,7 +97,7 @@ impl Storage {
                     }
                 }
             }
-        };
+        }
         Ok(paths)
     }
 }
@@ -109,7 +108,7 @@ impl OCIState {
             .index
             .get(&path)
             .ok_or_else(|| anyhow::anyhow!("missing OCI layer entry for path: {path:?}"))?;
-        let mut data = Vec::with_capacity(layer.size as usize);
+        let mut data = Vec::with_capacity(layer.size.try_into()?);
         self.pull_blob(layer, &mut data).await?;
         Ok(String::from_utf8(data)?)
     }
@@ -133,7 +132,7 @@ impl OCIState {
             &self.client,
             &self.reference,
             &self.auth,
-            descriptor.deref(),
+            descriptor,
             self.config.compressed || matches!(descriptor, Descriptor::ListOciDescriptor(..)),
         )
         .await?;
@@ -164,7 +163,7 @@ pub(crate) async fn pull_blob_cached(
     client
         .store_auth_if_needed(reference.registry(), auth)
         .await;
-    let mut out = Vec::with_capacity(descriptor.size as usize);
+    let mut out = Vec::with_capacity(descriptor.size.try_into()?);
     client.pull_blob(reference, &descriptor, &mut out).await?;
 
     if !encoded {

--- a/src/gather/writer.rs
+++ b/src/gather/writer.rs
@@ -53,6 +53,7 @@ use super::representation::{ArchivePath, Representation};
 pub struct ArchiveSearch(PathBuf);
 
 impl ArchiveSearch {
+    #[must_use]
     pub fn path(&self) -> PathBuf {
         self.0.clone()
     }
@@ -106,22 +107,25 @@ pub struct Archive(PathBuf);
 
 /// Creates a new Archive instance with the given path.
 impl Archive {
-    pub fn new(path: PathBuf) -> Self {
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
         Self(path)
     }
 
+    #[must_use]
     pub fn path(&self) -> PathBuf {
         self.0.clone()
     }
 
+    #[must_use]
     pub fn name(&self) -> &OsStr {
         self.0
             .components()
             .next_back()
-            .map(|c| c.as_os_str())
-            .unwrap_or(OsStr::new("snapshot"))
+            .map_or(OsStr::new("snapshot"), std::path::Component::as_os_str)
     }
 
+    #[must_use]
     pub fn join(&self, path: ArchivePath) -> PathBuf {
         match path {
             ArchivePath::Empty => self.path(),
@@ -148,8 +152,8 @@ impl From<Archive> for PathBuf {
 }
 
 impl From<PathBuf> for Archive {
-    fn from(val: PathBuf) -> Archive {
-        Archive(val)
+    fn from(val: PathBuf) -> Self {
+        Self(val)
     }
 }
 
@@ -189,6 +193,7 @@ impl From<&str> for Encoding {
 }
 
 /// The Writer enum represents the different archive writer implementations.
+///
 /// Gzip uses the gzip compression format.
 /// Zip uses the zip compression format.
 /// Oci uses the remote image reference as a destination.
@@ -252,7 +257,7 @@ impl Writer {
 
     /// Finish writing the archive, finalizing any compression and flushing buffers.
     pub async fn finish_oci(&self) -> anyhow::Result<()> {
-        if let Writer::Oci(ocistate) = self {
+        if let Self::Oci(ocistate) = self {
             return ocistate.publish_image().await;
         }
 
@@ -284,7 +289,8 @@ impl Writer {
             }
             Self::Gzip(Archive(archive), builder) => {
                 let mut header = Header::new_gnu();
-                header.set_size(data.len() as u64 + 1);
+                let size = data.len() + 1;
+                header.set_size(size.try_into()?);
                 header.set_cksum();
                 header.set_mode(0o644);
 
@@ -330,8 +336,13 @@ impl Writer {
 
                 // generate diff and write
                 let original = Reader::new(
-                    ArchiveReader::new(archive.clone(), &Storage::FS, DEFAULT_OCI_BUFFER_SIZE)
-                        .await,
+                    ArchiveReader::new(
+                        archive.clone(),
+                        &Storage::FS,
+                        DEFAULT_OCI_BUFFER_SIZE,
+                        false,
+                    )
+                    .await,
                     Utc::now(),
                     Storage::FS,
                 )
@@ -377,7 +388,7 @@ impl Writer {
                 DirBuilder::new().recursive(true).create(parent)?;
             }
             Some(_) | None => (),
-        };
+        }
 
         Ok(match encoding {
             Encoding::Path => Self::Path(archive.clone()),
@@ -427,7 +438,7 @@ impl OCIState {
                 .ok_or(anyhow::anyhow!("archive path is not convertable to string"))?,
         ))?;
 
-        let resource_paths = Arc::new(Mutex::new(Default::default()));
+        let resource_paths = Arc::new(Mutex::new(BTreeMap::default()));
         let non_resource_paths: Vec<PathBuf> = stream::iter(paths.into_iter())
             .filter_map(|path| Self::prepare_resource_layer(path, resource_paths.clone()))
             .collect()
@@ -465,11 +476,11 @@ impl OCIState {
         let (digest, size) = self.push_blob(config.data).await?;
 
         let mut manifest = OciImageManifest::default();
-        manifest.config.media_type = config.media_type.to_string();
+        manifest.config.media_type = config.media_type.clone();
         manifest.layers = layers.lock().await.clone();
         manifest.layers.sort_by(|a, b| a.digest.cmp(&b.digest));
         manifest.config.digest = digest;
-        manifest.config.size = size as i64;
+        manifest.config.size = size.try_into()?;
 
         info!("Pushing manifest: {}", self.image_ref);
         let manifest = manifest.into();
@@ -532,7 +543,7 @@ impl OCIState {
                         index
                     },
                 });
-                index += 4
+                index += 4;
             }
         }
 
@@ -584,7 +595,7 @@ impl OCIState {
             // That could only happen for empty logs, so we publish an empty json instead
             // as ghcr doesn't allow empty layers
             data = "{}".to_string();
-        };
+        }
 
         info!("Pushing layer: {:?}", archive_path);
         let (digest, size) = self.push_blob(data).await?;
@@ -594,11 +605,11 @@ impl OCIState {
                 urls: None,
                 media_type: IMAGE_LAYER_MEDIA_TYPE.to_string(),
                 digest,
-                size: size as i64,
+                size: size.try_into()?,
                 annotations: Some(
                     [(
                         "org.opencontainers.image.title".to_string(),
-                        archive_path.to_string(),
+                        archive_path.clone(),
                     )]
                     .into(),
                 ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub async fn run_cli() -> anyhow::Result<()> {
     let cli = cli::Cli::parse();
     cli.init();
 
-    cli.command.run().await?;
+    Box::pin(cli.command.run()).await?;
 
     tracing::info!("Done");
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,5 @@ extern crate scopeguard;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    crust_gather::run_cli().await
+    Box::pin(crust_gather::run_cli()).await
 }

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -5,8 +5,8 @@ use chrono::{DateTime, Utc};
 use oci_client::{Reference, secrets::RegistryAuth};
 use rmcp::{
     ServerHandler, ServiceExt,
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::*,
+    handler::server::wrapper::Parameters,
+    model::{ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router,
 };
 use serde::{Deserialize, Serialize};
@@ -165,7 +165,6 @@ struct ServeRuntime {
 }
 
 pub struct CrustGatherMcp {
-    tool_router: ToolRouter<CrustGatherMcp>,
     runtime: Arc<Mutex<ServeRuntime>>,
 }
 
@@ -240,7 +239,6 @@ impl CrustGatherMcp {
 impl Default for CrustGatherMcp {
     fn default() -> Self {
         Self {
-            tool_router: Self::tool_router(),
             runtime: Arc::new(Mutex::new(ServeRuntime::default())),
         }
     }
@@ -347,6 +345,7 @@ impl CrustGatherMcp {
             archives,
             Socket::try_from(socket.as_str())?,
             Some(temp_kubeconfig.path().to_path_buf()),
+            false,
         )
         .await?;
 
@@ -411,6 +410,7 @@ impl CrustGatherMcp {
             registry,
             Socket::try_from(socket.as_str())?,
             Some(temp_kubeconfig.path().to_path_buf()),
+            false,
         )
         .await?;
 
@@ -513,8 +513,7 @@ impl CrustGatherMcp {
             runtime
                 .current
                 .as_ref()
-                .map(|server| server.task.is_finished())
-                .unwrap_or(false)
+                .is_some_and(|server| server.task.is_finished())
         };
 
         if !finished {

--- a/src/scanners/dynamic.rs
+++ b/src/scanners/dynamic.rs
@@ -23,6 +23,7 @@ pub struct Dynamic {
 }
 
 impl Dynamic {
+    #[must_use]
     pub fn new(config: Config, resource: ApiResource) -> Self {
         Self {
             collectable: Objects::new(config, resource),
@@ -44,7 +45,7 @@ impl Collect<DynamicObject> for Dynamic {
         self.collectable.filter(obj)
     }
 
-    /// Converts the provided DynamicObject into a vector of Representation
+    /// Converts the provided `DynamicObject` into a vector of Representation
     /// with YAML object data and output path for the object.
     #[instrument(skip_all, fields(
         kind = self.resource().to_type_meta().kind,
@@ -88,9 +89,9 @@ mod test {
     use tempfile::TempDir;
     use tokio::time::timeout;
 
-    use crate::cli::DEFAULT_OCI_BUFFER_SIZE;
+    use crate::cli::{DEFAULT_OCI_BUFFER_SIZE, DebugPod};
     use crate::filters::filter::Include;
-    use crate::gather::config::GatherMode;
+    use crate::gather::config::{GatherMode, Secrets};
     use crate::{
         filters::{
             filter::{FilterGroup, FilterList},
@@ -171,12 +172,12 @@ mod test {
                     .await
                     .expect("failed to create builder")
                     .into(),
-                    secrets: Default::default(),
+                    secrets: Secrets::default(),
                     mode: GatherMode::Collect,
-                    additional_logs: Default::default(),
+                    additional_logs: Vec::default(),
                     duration: "1m".try_into().unwrap(),
-                    systemd_units: Default::default(),
-                    debug_pod: Default::default(),
+                    systemd_units: Vec::default(),
+                    debug_pod: DebugPod::default(),
                     disable_additional_logs: false,
                     skip_logs_collection: false,
                     skip_events_collection: false,

--- a/src/scanners/host_logs.rs
+++ b/src/scanners/host_logs.rs
@@ -20,7 +20,7 @@ use kube::{
     api::TypeMeta,
     core::{
         ApiResource, DynamicObject, ObjectMeta, ResourceExt, WatchEvent,
-        params::{DeleteParams, WatchParams},
+        params::{DeleteParams, PostParams, WatchParams},
         subresource::AttachParams,
     },
 };
@@ -106,9 +106,9 @@ impl Debug for HostLogs {
 impl From<Config> for HostLogs {
     fn from(value: Config) -> Self {
         let mut logs = value.additional_logs.clone();
-        for systemd_unit in value.systemd_units.iter() {
+        for systemd_unit in &value.systemd_units {
             logs.push(CustomLog {
-                path: systemd_unit.to_string(),
+                path: systemd_unit.clone(),
                 command: format!(
                     "chroot /host /bin/sh <<\"EOT\"\njournalctl -u {systemd_unit}\nEOT"
                 ),
@@ -219,7 +219,7 @@ impl HostLogs {
 
         let obj = serde_json::to_value(&archive_pod)?;
         let mut data: DynamicObject = serde_json::from_value(obj)?;
-        data.types = Some(data.types.unwrap_or(TypeMeta::resource::<Pod>()));
+        data.types = Some(data.types.unwrap_or_else(TypeMeta::resource::<Pod>));
 
         Ok(Representation::new()
             .with_path(ArchivePath::to_path(pod, TypeMeta::resource::<Pod>()))
@@ -249,8 +249,13 @@ impl HostLogs {
     fn get_template_pod(debug_pod: &DebugPod, node_name: String) -> Pod {
         Pod {
             metadata: ObjectMeta {
-                name: Some(node_name.to_string()),
-                namespace: Some(debug_pod.namespace.clone().unwrap_or("default".to_string())),
+                name: Some(node_name.clone()),
+                namespace: Some(
+                    debug_pod
+                        .namespace
+                        .clone()
+                        .unwrap_or_else(|| "default".to_string()),
+                ),
                 creation_timestamp: Some(Time(Timestamp::now())),
                 ..Default::default()
             },
@@ -297,9 +302,7 @@ impl HostLogs {
                 }]),
                 ..Default::default()
             }),
-            status: Some(PodStatus {
-                ..Default::default()
-            }),
+            status: Some(PodStatus::default()),
         }
     }
 
@@ -307,7 +310,7 @@ impl HostLogs {
     async fn get_or_create(&self, pod: Pod) -> anyhow::Result<()> {
         let api = Api::namespaced(
             self.get_api().into(),
-            &pod.namespace().unwrap_or("default".to_string()),
+            &pod.namespace().unwrap_or_else(|| "default".to_string()),
         );
 
         let found = api
@@ -317,10 +320,10 @@ impl HostLogs {
 
         if found.is_none() {
             tracing::info!("Creating user logs debug pod");
-            api.create(&Default::default(), &pod)
+            api.create(&PostParams::default(), &pod)
                 .await
                 .map_err(DebugPodError::Create)?;
-        };
+        }
 
         Ok(())
     }
@@ -333,7 +336,7 @@ impl HostLogs {
                 .debug_pod
                 .namespace
                 .clone()
-                .unwrap_or("default".to_string()),
+                .unwrap_or_else(|| "default".to_string()),
         );
         api.delete(&pod.name_any(), &DeleteParams::default().grace_period(0))
             .await?;
@@ -354,7 +357,7 @@ impl HostLogs {
 
         let api = Api::namespaced(
             self.get_api().into(),
-            &pod.namespace().unwrap_or("default".to_string()),
+            &pod.namespace().unwrap_or_else(|| "default".to_string()),
         );
         let mut stream = api.watch(&wp, "0").await?.boxed();
         while let Some(event) = stream.try_next().await? {
@@ -362,7 +365,7 @@ impl HostLogs {
                 && Self::pod_ready(&pod)
             {
                 break;
-            };
+            }
         }
 
         Ok(vec![
@@ -392,7 +395,7 @@ impl HostLogs {
     ) -> anyhow::Result<Representation> {
         let api: Api<Pod> = Api::namespaced(
             self.get_api().into(),
-            &pod.namespace().unwrap_or("default".to_string()),
+            &pod.namespace().unwrap_or_else(|| "default".to_string()),
         );
         let args = vec!["sh", "-c", command];
 
@@ -423,6 +426,8 @@ impl HostLogs {
 
 #[cfg(test)]
 mod test {
+    use k8s_openapi::api::core::v1::PodStatus;
+
     use super::*;
 
     #[test]

--- a/src/scanners/info.rs
+++ b/src/scanners/info.rs
@@ -26,6 +26,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new(config: Config) -> Self {
         Self {
             collectable: Objects::new_typed(config),

--- a/src/scanners/interface.rs
+++ b/src/scanners/interface.rs
@@ -8,7 +8,7 @@ use k8s_openapi::serde_json;
 use kube::Api;
 use kube::api::WatchEvent;
 use kube::core::gvk::ParseGroupVersionError;
-use kube::core::params::ListParams;
+use kube::core::params::{ListParams, WatchParams};
 use kube::core::{DynamicObject, ResourceExt, Status};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -68,6 +68,7 @@ pub const DELETED_ANNOTATION: &str = "crust-gather.io/deleted";
 pub trait Collect<R: ResourceThreadSafe>: Send {
     /// Default retry policy - exponential backoff.
     /// Starts at 10ms, doubles each iteration, up to max of 60s.
+    #[must_use]
     fn retry_policy() -> ExponentialBuilder {
         ExponentialBuilder::default()
             .with_min_delay(Duration::from_millis(10))
@@ -102,11 +103,11 @@ pub trait Collect<R: ResourceThreadSafe>: Send {
         ArchivePath::to_path(obj, self.resource().to_type_meta())
     }
 
-    /// Filters objects based on their GroupVersionKind and the object itself.
+    /// Filters objects based on their `GroupVersionKind` and the object itself.
     /// Returns true if the object should be included, false otherwise.
     fn filter(&self, object: &R) -> Result<bool, CollectError>;
 
-    /// Converts the provided DynamicObject into a vector of Representation
+    /// Converts the provided `DynamicObject` into a vector of Representation
     /// with YAML object data and output path for the object.
     #[instrument(skip_all, fields(
         kind = self.resource().to_type_meta().kind,
@@ -131,13 +132,13 @@ pub trait Collect<R: ResourceThreadSafe>: Send {
     /// Returns the Kubernetes API client for the resource type this scanner handles.
     fn get_api(&self) -> Api<R>;
 
-    /// Returns the TypeMetaGetter for the API resource type this scanner handles.
-    /// Used to set the TypeMeta on the returned objects in the list,
+    /// Returns the `TypeMetaGetter` for the API resource type this scanner handles.
+    /// Used to set the `TypeMeta` on the returned objects in the list,
     /// as the API server does not provide this data in the response.
     fn resource(&self) -> impl TypeMetaGetter;
 
     /// Lists Kubernetes objects of the type handled by this scanner, and set
-    /// the get_type_meta() information on the objects. Objects are filtered
+    /// the `get_type_meta()` information on the objects. Objects are filtered
     /// before getting added to the result.
     #[instrument(skip_all, fields(kind = self.resource().to_type_meta().kind, apiVersion = self.resource().to_type_meta().api_version), err)]
     async fn list(&self) -> anyhow::Result<Vec<R>> {
@@ -212,7 +213,7 @@ pub trait Collect<R: ResourceThreadSafe>: Send {
 
         let mut stream = self
             .get_api()
-            .watch(&Default::default(), "0")
+            .watch(&WatchParams::default(), "0")
             .await?
             .boxed();
 
@@ -223,19 +224,19 @@ pub trait Collect<R: ResourceThreadSafe>: Send {
                     let mut obj = obj.clone();
                     obj.annotations_mut()
                         .insert(ADDED_ANNOTATION.to_string(), now);
-                    self.sync_with_retry(&obj).await?
+                    self.sync_with_retry(&obj).await?;
                 }
                 WatchEvent::Modified(obj) => {
                     let mut obj = obj.clone();
                     obj.annotations_mut()
                         .insert(UPDATED_ANNOTATION.to_string(), now);
-                    self.sync_with_retry(&obj).await?
+                    self.sync_with_retry(&obj).await?;
                 }
                 WatchEvent::Deleted(obj) => {
                     let mut obj = obj.clone();
                     obj.annotations_mut()
                         .insert(DELETED_ANNOTATION.to_string(), now);
-                    self.sync_with_retry(&obj).await?
+                    self.sync_with_retry(&obj).await?;
                 }
                 WatchEvent::Error(e) => Err(WatchError::Stream(e))?,
                 WatchEvent::Bookmark(_) => (),

--- a/src/scanners/logs.rs
+++ b/src/scanners/logs.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::{api::core::v1::Pod, jiff::Timestamp};
 use kube::Api;
 use kube::{
     api::TypeMeta,
@@ -30,7 +30,7 @@ use super::{
 #[error("Failed to collect logs: {0:?}")]
 pub struct LogsError(kube::Error);
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum LogSelection {
     Current,
     Previous,
@@ -39,8 +39,8 @@ pub enum LogSelection {
 impl Display for LogSelection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LogSelection::Current => write!(f, "current.log"),
-            LogSelection::Previous => write!(f, "previous.log"),
+            Self::Current => write!(f, "current.log"),
+            Self::Previous => write!(f, "previous.log"),
         }
     }
 }
@@ -71,6 +71,7 @@ impl Debug for Logs {
 }
 
 impl Logs {
+    #[must_use]
     pub fn new(config: Config, group: LogSelection) -> Self {
         Self {
             skip_logs_collection: config.skip_logs_collection,
@@ -113,7 +114,7 @@ impl Collect<Pod> for Logs {
                 pod.name_any().as_str(),
                 &LogParams {
                     container: Some(container.name.clone()),
-                    since_time: Some(Default::default()),
+                    since_time: Some(Timestamp::default()),
                     timestamps: true,
                     ..self.group.clone().into()
                 },
@@ -169,9 +170,9 @@ mod test {
     use tempfile::TempDir;
     use tokio::time::timeout;
 
-    use crate::cli::DEFAULT_OCI_BUFFER_SIZE;
+    use crate::cli::{DEFAULT_OCI_BUFFER_SIZE, DebugPod};
     use crate::filters::filter::Include;
-    use crate::gather::config::GatherMode;
+    use crate::gather::config::{GatherMode, Secrets};
     use crate::{
         filters::{
             filter::{FilterGroup, FilterList},
@@ -244,12 +245,12 @@ mod test {
                 .await
                 .expect("failed to create builder")
                 .into(),
-                secrets: Default::default(),
+                secrets: Secrets::default(),
                 mode: GatherMode::Collect,
-                additional_logs: Default::default(),
+                additional_logs: Vec::default(),
                 duration: "1m".try_into().unwrap(),
-                systemd_units: Default::default(),
-                debug_pod: Default::default(),
+                systemd_units: Vec::default(),
+                debug_pod: DebugPod::default(),
                 disable_additional_logs: false,
             }),
             group: LogSelection::Current,

--- a/src/scanners/objects.rs
+++ b/src/scanners/objects.rs
@@ -38,6 +38,7 @@ impl<R> Objects<R>
 where
     R: Resource<DynamicType = ApiResource> + ResourceReq,
 {
+    #[must_use]
     pub fn new(config: Config, resource: ApiResource) -> Self {
         Self {
             api: Api::all_with(config.client, &resource),
@@ -54,6 +55,7 @@ where
     R: ResourceThreadSafe,
     R::DynamicType: Default,
 {
+    #[must_use]
     pub fn new_typed(config: Config) -> Self {
         Self {
             api: Api::all(config.client),
@@ -112,13 +114,13 @@ mod test {
     use kube::core::{ApiResource, DynamicObject, params::PostParams};
 
     use crate::{
-        cli::DEFAULT_OCI_BUFFER_SIZE,
+        cli::{DEFAULT_OCI_BUFFER_SIZE, DebugPod},
         filters::{
             filter::{FilterGroup, FilterList, Include},
             namespace::Namespace,
         },
         gather::{
-            config::{Config, GatherMode},
+            config::{Config, GatherMode, Secrets},
             representation::ArchivePath,
             writer::{Archive, Encoding, Writer},
         },
@@ -185,12 +187,12 @@ mod test {
                 .await
                 .expect("failed to create builder")
                 .into(),
-                secrets: Default::default(),
+                secrets: Secrets::default(),
                 mode: GatherMode::Collect,
-                additional_logs: Default::default(),
+                additional_logs: Vec::default(),
                 duration: "1m".try_into().unwrap(),
-                systemd_units: Default::default(),
-                debug_pod: Default::default(),
+                systemd_units: Vec::default(),
+                debug_pod: DebugPod::default(),
                 disable_additional_logs: false,
                 skip_logs_collection: false,
                 skip_events_collection: false,
@@ -231,12 +233,12 @@ mod test {
                 .await
                 .expect("failed to create builder")
                 .into(),
-                secrets: Default::default(),
+                secrets: Secrets::default(),
                 mode: GatherMode::Collect,
-                additional_logs: Default::default(),
+                additional_logs: Vec::default(),
                 duration: "1m".try_into().unwrap(),
-                systemd_units: Default::default(),
-                debug_pod: Default::default(),
+                systemd_units: Vec::default(),
+                debug_pod: DebugPod::default(),
                 disable_additional_logs: false,
                 skip_logs_collection: false,
                 skip_events_collection: false,
@@ -274,12 +276,12 @@ mod test {
                 .await
                 .expect("failed to create builder")
                 .into(),
-                secrets: Default::default(),
+                secrets: Secrets::default(),
                 mode: GatherMode::Collect,
-                additional_logs: Default::default(),
+                additional_logs: Vec::default(),
                 duration: "1m".try_into().unwrap(),
-                systemd_units: Default::default(),
-                debug_pod: Default::default(),
+                systemd_units: Vec::default(),
+                debug_pod: DebugPod::default(),
                 disable_additional_logs: false,
                 skip_logs_collection: false,
                 skip_events_collection: false,

--- a/src/scanners/versions.rs
+++ b/src/scanners/versions.rs
@@ -33,6 +33,7 @@ pub struct Versions {
 }
 
 impl Versions {
+    #[must_use]
     pub fn new(config: Config) -> Self {
         Self {
             collectable: Objects::new_typed(config),
@@ -66,7 +67,7 @@ impl Collect<Pod> for Versions {
                     name: meta.name.clone().unwrap_or_default(),
                     namespace: meta.namespace.clone().unwrap_or_default(),
                     container: container.name.clone(),
-                    version: container.image.clone().unwrap_or_default(),
+                    version: container.image.unwrap_or_default(),
                 })
             })
             .collect::<Vec<_>>();
@@ -190,6 +191,6 @@ mod tests {
   version: test
 "
             .to_string()
-        )
+        );
     }
 }


### PR DESCRIPTION
Add `--served-crs-only` option, allowing for some clients, less reliant on CRD introspection, to not get confused requesting CRs which are not served and stored ones.

By default, served: true and non-stored CRs are ok, as there is a webhook registered for the controller, exposing such CR. Unfortunately, in a statically served archive without any insight into the collected data, knowing how conversion between these versions works is not possible. The client might despite this attempt to request non storage served version anyway, and receive an empty list of resources.

For such cases, `--served-crs-only` flag should be used.